### PR TITLE
fix for build setup in sagemath environment

### DIFF
--- a/cnf/Makefile.in
+++ b/cnf/Makefile.in
@@ -67,7 +67,7 @@ $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
 $(LOCALBIN)/%.lo: src/%.C
-	./libtool --mode=compile --tag=CC $(CXX) $(CFLAGS) @GAP_CPPFLAGS@ @CXSC_CFLAGS@ @FPLLL_CFLAGS@ -o $@ -c $<
+	./libtool --mode=compile --tag=CC $(CXX) $(CFLAGS) @FPLLL_CFLAGS@ @CXSC_CFLAGS@ @GAP_CPPFLAGS@   -o $@ -c $<
 
 $(LOCALBIN)/%.lo: src/%.c
 	./libtool --mode=compile --tag=CC $(CC) $(CFLAGS) @GAP_CPPFLAGS@ @MPFR_CFLAGS@ @MPFI_CFLAGS@ @MPC_CFLAGS@ -std=c99 -o $@ -c $<


### PR DESCRIPTION
since Fplll is part of sagemath, the origin build flags cause the compiler to use the wrong includes from the fplll version in sage.5-7. Fixed with this commit.
