### PR TITLE
Remove call to FillInVersion()

### DIFF
--- a/src/float.c
+++ b/src/float.c
@@ -207,7 +207,6 @@ StructInitInfo *Init__float (void)
 StructInitInfo *Init__Dynamic (void)
 #endif
 {
-  FillInVersion( &module );
   return &module;
 }
 


### PR DESCRIPTION
The GAP kernel function FillInVersion() does nothing, and has been like that for quite some time.

 I'd like to remove it in a future GAP version, and float is one of only two packages to (still) use it (the other is pargap).

Thanks!
