### PR TITLE
Use GAP's compiled.h header

### DIFF
--- a/src/cxsc.C
+++ b/src/cxsc.C
@@ -19,17 +19,7 @@
 #include <gmp.h>
 
 extern "C" {
-#include "src/system.h"
-#include "src/gasman.h"
-#include "src/objects.h"
-#include "src/macfloat.h"
-#include "src/gap.h"
-#include "src/bool.h"
-#include "src/plist.h"
-#include "src/string.h"
-#include "src/gmpints.h"
-#include "src/calls.h"
-#include "src/opers.h"
+#include "src/compiled.h"
 }
 #undef ZERO // clashes with ZERO in cxsc
 #include "except.hpp"

--- a/src/fplll.C
+++ b/src/fplll.C
@@ -25,15 +25,7 @@
 #include <gmp.h>
 
 extern "C" {
-#include "src/system.h"
-#include "src/gasman.h"
-#include "src/objects.h"
-#include "src/macfloat.h"
-#include "src/gap.h"
-#include "src/bool.h"
-#include "src/plist.h"
-#include "src/calls.h"
-#include "src/opers.h"
+#include "src/compiled.h"
 #include "floattypes.h"
 }
 #include <fplll.h>

--- a/src/mpc.c
+++ b/src/mpc.c
@@ -20,14 +20,7 @@
 #include <stdio.h>
 #include <gmp.h>
 
-#include "src/system.h"
-#include "src/gasman.h"
-#include "src/objects.h"
-#include "src/gap.h"
-#include "src/gmpints.h"
-#include "src/bool.h"
-#include "src/string.h"
-#include "src/plist.h"
+#include "src/compiled.h"
 #include "floattypes.h"
 
 /****************************************************************

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -15,14 +15,7 @@
 #include <stdio.h>
 #include <gmp.h>
 
-#include "src/system.h"
-#include "src/gasman.h"
-#include "src/objects.h"
-#include "src/gap.h"
-#include "src/gmpints.h"
-#include "src/bool.h"
-#include "src/string.h"
-#include "src/plist.h"
+#include "src/compiled.h"
 #include "mp_float.h"
 
 /****************************************************************

--- a/src/mpfi.c
+++ b/src/mpfi.c
@@ -21,14 +21,7 @@
 #include <stdio.h>
 #include <gmp.h>
 
-#include "src/system.h"
-#include "src/gasman.h"
-#include "src/objects.h"
-#include "src/gap.h"
-#include "src/gmpints.h"
-#include "src/bool.h"
-#include "src/string.h"
-#include "src/plist.h"
+#include "src/compiled.h"
 #include "floattypes.h"
 
 #define LMANTISSA_MPFI(p) ((mp_limb_t *) (p+1))

--- a/src/mpfr.c
+++ b/src/mpfr.c
@@ -23,17 +23,7 @@
 #include <gmp.h>
 
 #include <mpfr.h>
-#include "src/system.h"
-#include "src/gasman.h"
-#include "src/objects.h"
-#include "src/gap.h"
-#include "src/gmpints.h"
-#include "src/bool.h"
-#include "src/string.h"
-#include "src/macfloat.h"
-#include "src/plist.h"
-#include "src/calls.h"
-#include "src/opers.h"
+#include "src/compiled.h"
 #include "floattypes.h"
 
 Obj TYPE_MPFR, IsMPFRFloat, GAP_INFINITY;


### PR DESCRIPTION
This replaces a lot includes of GAP headers by a single include of the `compiled.h` header.

This has the advantage that it will keep working even if we rename kernel header files -- and in fact, just that happened recently (`string.h` was renamed to `stringobj.h` by @markuspf for good reasons), which broke compilation of `float`.

With this patch, `float` should compile fine with past, present and future versions of GAP.