### PR TITLE
Migration: fplll: 4 to 5

### DIFF
--- a/m4/ac_check_fplll.m4
+++ b/m4/ac_check_fplll.m4
@@ -76,8 +76,10 @@ AC_CHECK_HEADER(fplll.h,,[temp_status=false],[#include <mpfr.h>])
 LDFLAGS="$LDFLAGS $FPLLL_LDFLAGS $MPFR_CFLAGS"
 LIBS="$LIBS -lfplll -lgmp"
 AC_MSG_CHECKING([for lllReduction in -lfplll])
-AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <fplll.h>],
-    [ZZ_mat<mpz_t> M(3,3); lllReduction(M, 0.99, 0.51, LM_WRAPPER);])],[AC_MSG_RESULT([yes])],[temp_status=false; AC_MSG_RESULT([no])])
+AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <fplll.h>],[
+ZZ_mat<mpz_t> M(3,3);
+lll_reduction(M, 0.99, 0.51, LM_WRAPPER);
+])],[AC_MSG_RESULT([yes])],[temp_status=false; AC_MSG_RESULT([no])])
 AC_LANG_POP([C++])
 
 if test "$temp_status" = false; then


### PR DESCRIPTION
Attempt to migrate from fplll 4 to fplll 5. Hacked on Debian Sid/experimental box.
Note that the __APPLE__ part was commented out.
Otherwise, some hacks can certainly be improved, in particular the one in
void SET_INTOBJ(Z_NR<double> &v, Obj z)
