### PR TITLE
tst/testall.g: indicate test status via exit code

### DIFF
--- a/tst/arithmetic.tst
+++ b/tst/arithmetic.tst
@@ -29,6 +29,3 @@ true
 gap> AbsoluteValue(Sin(y)) < 1.e-10;
 true
 gap> STOP_TEST( "arithmetic.tst", 3*10^8 );
-arithmetic
-
-#E arithmetic.tst . . . . . . . . . . . . . . . . . . . . . . . . . . . .ends here

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -2,19 +2,62 @@ LoadPackage("float");
 SetInfoLevel(InfoFloat,1);
 dirs := DirectoriesPackageLibrary("float","tst");
 
-SetFloats(IEEE754FLOAT);
-Test(Filename(dirs,"arithmetic.tst"),rec(compareFunction:="uptowhitespace"));
-SetFloats(MPFR);
-Test(Filename(dirs,"arithmetic.tst"),rec(compareFunction:="uptowhitespace"));
-SetFloats(MPFI);
-Test(Filename(dirs,"arithmetic.tst"),rec(compareFunction:="uptowhitespace"));
-SetFloats(MPC);
-Test(Filename(dirs,"arithmetic.tst"),rec(compareFunction:="uptowhitespace"));
-field := MPC_PSEUDOFIELD;
-Test(Filename(dirs,"polynomials.tst"),rec(compareFunction:="uptowhitespace"));
-SetFloats(CXSC);
-Test(Filename(dirs,"arithmetic.tst"),rec(compareFunction:="uptowhitespace"));
-field := CXSC_PSEUDOFIELD;
-Test(Filename(dirs,"polynomials.tst"),rec(compareFunction:="uptowhitespace"));
+success := true;
 
-Test(Filename(dirs,"fplll.tst"),rec(compareFunction:="uptowhitespace"));
+# test machine floats
+SetFloats(IEEE754FLOAT);
+success := success and Test(Filename(dirs,"arithmetic.tst"));
+
+if IsBound(MPFR_INT) then
+    Print("#I  testing MPFR...\n");
+    SetFloats(MPFR);
+    success := success and Test(Filename(dirs,"arithmetic.tst"));
+else
+    Print("#I  WARNING: skipping tests for MPFR\n");
+fi;
+
+if IsBound(MPFI_INT) then
+    Print("#I  testing MPFI...\n");
+    SetFloats(MPFI);
+    success := success and Test(Filename(dirs,"arithmetic.tst"));
+else
+    Print("#I  WARNING: skipping tests for MPFI\n");
+fi;
+
+if IsBound(MPC_INT) then
+    Print("#I  testing MPC...\n");
+    SetFloats(MPC);
+    success := success and Test(Filename(dirs,"arithmetic.tst"));
+
+    field := MPC_PSEUDOFIELD;
+    success := success and Test(Filename(dirs,"polynomials.tst"));
+else
+    Print("#I  WARNING: skipping tests for MPC\n");
+fi;
+
+if IsBound(CXSC_INT) then
+    Print("#I  testing CXSC...\n");
+    SetFloats(CXSC);
+    success := success and Test(Filename(dirs,"arithmetic.tst"));
+
+    field := CXSC_PSEUDOFIELD;
+    success := success and Test(Filename(dirs,"polynomials.tst"));
+else
+    Print("#I  WARNING: skipping tests for CXSC\n");
+fi;
+
+if IsBound(@FPLLL) then
+    Print("#I  testing FPLLL...\n");
+    success := success and Test(Filename(dirs,"fplll.tst"));
+else
+    Print("#I  WARNING: skipping tests for FPLLL\n");
+fi;
+
+# Report test results
+if success then
+    Print("#I  No errors detected while testing package float\n");
+    QUIT_GAP(0);
+else
+    Print("#I  Errors detected while testing package float\n");
+    QUIT_GAP(1);
+fi;


### PR DESCRIPTION
This helps the GAP team automate tracking regressions in packages,
e.g. caused by work on GAP itself.