### PR TITLE
Remove remaining code for building things in extern/

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -121,7 +121,7 @@ checkblocks:
 	comm -3 @@-blocks @@-in
 	@rm @@-blocks @@-in
 
-all: @MAKE_LIBTARGETS@ all-recursive
+all: all-recursive
 	mkdir -p bin/@GAPARCH@
 	cp src/.libs/float.so bin/@GAPARCH@/
 

--- a/configure.ac
+++ b/configure.ac
@@ -42,20 +42,12 @@ AC_SUBST(GMP_LDFLAGS)
 AC_SYS_IS_CYGWIN
 AC_SYS_IS_DARWIN
 
-# External libraries configuration
-EXTERN="\$(CURDIR)/bin/$TARGET/extern"
-MAKE_LIBTARGETS=""
-
 LT_LIB_M
 AC_CHECK_MPFR
 AC_CHECK_MPFI
 AC_CHECK_MPC
 AC_CHECK_CXSC
 AC_CHECK_FPLLL
-
-if ! test -z $MAKE_LIBTARGETS; then # disable external compilation
-    AC_ERROR([Compilation of the external libraries $MAKE_LIBTARGETS was requested, but is now disabled. Please install them manually and rerun configure.])
-fi
 
 # how to get files from the web
 WGET=""

--- a/m4/ac_check_cxsc.m4
+++ b/m4/ac_check_cxsc.m4
@@ -1,7 +1,7 @@
 # check for cxsc library
-# sets CXSC_CFLAGS, CXSC_LDFLAGS, CXSC_MAKELIB and CXSC_LIBS,
+# sets CXSC_CFLAGS, CXSC_LDFLAGS and CXSC_LIBS,
 # and CXSC_WITH, CXSC_DEPEND,
-# and CXSC=yes/no/extern
+# and CXSC=yes/no
 
 AC_DEFUN([AC_CHECK_CXSC],[
 temp_LIBS="$LIBS"
@@ -11,32 +11,14 @@ CXSC=unknown
 CXSC_WITH=""
 CXSC_DEPEND=""
 
-# a dirty hack: we'll pretend our home directory
-# is $(EXTERN), and the installation will go into $(EXTERN)/cxsc
-
-CXSC_MAKELIB=`printf 'cxsc: $(CXSCLIB).tar.gz \\
-	mkdir -p $(EXTERN) \\
-	rm -f $(EXTERN)/cxsc \\
-	ln -s . $(EXTERN)/cxsc \\
-	if ! test -r $(EXTERN)/include/real.hpp; then \\
-	    rm -rf $(CXSCLIB) && \\
-	    tar -x -f $(CXSCLIB).tar.gz -z -C extern && \\
-	    cd $(CXSCLIB) && \\
-	    (echo "yes"; for i in 1 2 3 4 5 6 7 8 9 10; do echo ""; done) | \\
-		HOME=$(EXTERN) ./install_cxsc; \\
-	fi\n'`
-
 AC_ARG_WITH(cxsc,
  [  --with-cxsc=<location>
     Location at which the CXSC library was installed.
     If the argument is omitted, the library is assumed to be reachable
     under the standard search path (/usr, /usr/local,...).  Otherwise
     you must give the <path> to the directory which contains the
-    library. The special value "extern" asks Float
-    to compile a version of cxsc in the subdirectory extern/.],
- [if test "$withval" = extern; then
-    CXSC=extern
-  elif test "$withval" = no; then
+    library..],
+ [if test "$withval" = no; then
     CXSC=no
   elif test "$withval" = yes; then
     CXSC=yes
@@ -68,8 +50,6 @@ if test "$CXSC" != no; then
 
 CXSC_LIBS="-lcxsc"
 
-if test "$CXSC" != extern; then
-
 AC_LANG_PUSH([C++])
 temp_status=true
 CPPFLAGS="$CPPFLAGS $CXSC_CFLAGS"
@@ -80,25 +60,12 @@ AC_LANG_POP([C++])
 
 if test "$temp_status" = false; then
     if test "$CXSC" = yes; then
-        AC_MSG_ERROR([library cxsc not found. Using --with-cxsc, specify its location, "extern" to compile it locally, or "no" to disable it.])
+        AC_MSG_ERROR([library cxsc not found. Using --with-cxsc, specify its location, or "no" to disable it.])
     else
-        CXSC=extern
+        CXSC=no
     fi
 else
     CXSC=yes
-fi
-
-fi
-
-if test "$CXSC" = extern; then
-
-MAKE_LIBTARGETS="$MAKE_LIBTARGETS cxsc"
-CXSC_CFLAGS='-I$(EXTERN)/include'
-CXSC_LDFLAGS='-L$(EXTERN)/lib'
-
-CXSC_WITH='--with-cxsc=$(EXTERN)'
-CXSC_DEPEND='cxsc'
-
 fi
 
 fi
@@ -113,7 +80,5 @@ fi
 AC_SUBST(CXSC_CFLAGS)
 AC_SUBST(CXSC_LDFLAGS)
 AC_SUBST(CXSC_LIBS)
-AC_SUBST(CXSC_MAKELIB)
-AC_SUBST(MAKE_LIBTARGETS)
 AM_CONDITIONAL([WITH_CXSC_IS_YES],[test x"$CXSC" != xno])
 ])

--- a/m4/ac_check_fplll.m4
+++ b/m4/ac_check_fplll.m4
@@ -1,7 +1,7 @@
 # check for fplll library
-# sets FPLLL_CFLAGS, FPLLL_LDFLAGS, FPLLL_MAKELIB and FPLLL_LIBS,
+# sets FPLLL_CFLAGS, FPLLL_LDFLAGS and FPLLL_LIBS,
 # and FPLLL_WITH, FPLLL_DEPEND,
-# and FPLLL=yes/no/extern
+# and FPLLL=yes/no
 
 AC_DEFUN([AC_CHECK_FPLLL],[
 temp_LIBS="$LIBS"
@@ -11,27 +11,14 @@ FPLLL=unknown
 FPLLL_WITH=""
 FPLLL_DEPEND=""
 
-FPLLL_MAKELIB=`printf 'fplll: $(FPLLLLIB).tar.gz %s \\
-	mkdir -p $(EXTERN)/include $(EXTERN)/lib \\
-	if ! test -r $(EXTERN)/include/fplll.h; then \\
-	    rm -rf $(FPLLLLIB) && \\
-	    tar -x -f $(FPLLLLIB).tar.gz -z -C extern && \\
-	    cd $(FPLLLLIB) && \\
-	    ./configure CPPFLAGS="%s %s $(CPPFLAGS)" LDFLAGS="%s %s $(LDFLAGS)" %s %s --prefix=$(EXTERN) && \\
-	    $(MAKE) install; \\
-	fi\n' "$MPFR_DEPEND" "$GMP_CFLAGS" "$MPFR_CFLAGS" "$GMP_LDFLAGS" "$MPFR_LDFLAGS" "$GMP_WITH" "$MPFR_WITH"`
-
 AC_ARG_WITH(fplll,
  [  --with-fplll=<location>
     Location at which the FPLLL library was installed.
     If the argument is omitted, the library is assumed to be reachable
     under the standard search path (/usr, /usr/local,...).  Otherwise
     you must give the <path> to the directory which contains the
-    library. The special value "extern" asks Float
-    to compile a version of fplll in the subdirectory extern/.],
- [if test "$withval" = extern; then
-    FPLLL=extern
-  elif test "$withval" = no; then
+    library.],
+ [if test "$withval" = no; then
     FPLLL=no
   elif test "$withval" = yes; then
     FPLLL=yes
@@ -67,8 +54,6 @@ fi
 
 FPLLL_LIBS="-lfplll"
 
-if test "$FPLLL" != extern; then
-
 AC_LANG_PUSH([C++])
 CPPFLAGS="$CPPFLAGS $FPLLL_CFLAGS $MPFR_CFLAGS"
 AC_CHECK_HEADER(fplll.h,[found_fplll=true],[found_fplll=false],[#include <mpfr.h>])
@@ -89,28 +74,16 @@ AC_LANG_POP([C++])
 
 if test "$found_fplll" = false; then
     if test "$FPLLL" = yes; then
-        AC_MSG_ERROR([library fplll not found. Using --with-fplll, specify its location, "extern" to compile it locally, or "no" to disable it.])
+        AC_MSG_ERROR([library fplll not found. Using --with-fplll, specify its location, or "no" to disable it.])
     else
-        FPLLL=extern
-	found_fplll=4
+        FPLLL=no
+        found_fplll=4
     fi
 else
     FPLLL=yes
 fi
 FPLLL_VERSION="$found_fplll"
 AC_DEFINE([FPLLL_VERSION], [], [fplll major version])
-fi
-
-if test "$FPLLL" = extern; then
-
-MAKE_LIBTARGETS="$MAKE_LIBTARGETS fplll"
-FPLLL_CFLAGS='-I$(EXTERN)/include'
-FPLLL_LDFLAGS='-L$(EXTERN)/lib'
-
-FPLLL_WITH='--with-fplll=$(EXTERN)'
-FPLLL_DEPEND='fplll'
-
-fi
 
 fi
 
@@ -124,7 +97,5 @@ fi
 AC_SUBST(FPLLL_CFLAGS)
 AC_SUBST(FPLLL_LDFLAGS)
 AC_SUBST(FPLLL_LIBS)
-AC_SUBST(FPLLL_MAKELIB)
-AC_SUBST(MAKE_LIBTARGETS)
 AM_CONDITIONAL([WITH_FPLLL_IS_YES],[test x"$FPLLL" != xno])
 ])

--- a/m4/ac_check_mpc.m4
+++ b/m4/ac_check_mpc.m4
@@ -1,7 +1,7 @@
 # check for mpc library
-# sets MPC_CFLAGS, MPC_LDFLAGS, MPC_MAKELIB and MPC_LIBS,
+# sets MPC_CFLAGS, MPC_LDFLAGS and MPC_LIBS,
 # and MPC_WITH, MPC_DEPEND,
-# and MPC=yes/no/extern
+# and MPC=yes/no
 
 AC_DEFUN([AC_CHECK_MPC],[
 temp_LIBS="$LIBS"
@@ -11,27 +11,14 @@ MPC=unknown
 MPC_WITH=""
 MPC_DEPEND=""
 
-MPC_MAKELIB=`printf 'mpc: $(MPCLIB).tar.gz %s  \\
-	mkdir -p $(EXTERN)/include $(EXTERN)/lib  \\
-	if ! test -r $(EXTERN)/include/mpc.h; then \\
-	    rm -rf $(MPCLIB) && \\
-	    tar -x -f $(MPCLIB).tar.gz -z -C extern && \\
-	    cd $(MPCLIB) && \\
-	    ./configure %s %s --prefix=$(EXTERN) && \\
-	    $(MAKE) install; \\
-	fi\n' "$MPFR_DEPEND" "$GMP_WITH" "$MPFR_WITH"`
-
 AC_ARG_WITH(mpc,
  [  --with-mpc=<location>
     Location at which the MPC library was installed.
     If the argument is omitted, the library is assumed to be reachable
     under the standard search path (/usr, /usr/local,...).  Otherwise
     you must give the <path> to the directory which contains the
-    library. The special value "extern" asks Float
-    to compile a version of mpc in the subdirectory extern/.],
- [if test "$withval" = extern; then
-    MPC=extern
-  elif test "$withval" = no; then
+    library.],
+ [if test "$withval" = no; then
     MPC=no
   elif test "$withval" = yes; then
     MPC=yes
@@ -67,8 +54,6 @@ fi
 
 MPC_LIBS="-lmpc"
 
-if test "$MPC" != extern; then
-
 AC_LANG_PUSH([C])
 temp_status=true
 CPPFLAGS="$CPPFLAGS $MPC_CFLAGS $MPFR_CFLAGS"
@@ -79,25 +64,12 @@ AC_LANG_POP([C])
 
 if test "$temp_status" = false; then
     if test "$MPC" = yes; then
-        AC_MSG_ERROR([library mpc not found. Using --with-mpc, specify its location, "extern" to compile it locally, or "no" to disable it.])
+        AC_MSG_ERROR([library mpc not found. Using --with-mpc, specify its location, or "no" to disable it.])
     else
-        MPC=extern
+        MPC=no
     fi
 else
     MPC=yes
-fi
-
-fi
-
-if test "$MPC" = extern; then
-
-MAKE_LIBTARGETS="$MAKE_LIBTARGETS mpc"
-MPC_CFLAGS='-I$(EXTERN)/include'
-MPC_LDFLAGS='-L$(EXTERN)/lib'
-
-MPC_WITH='--with-mpc=$(EXTERN)'
-MPC_DEPEND='mpc'
-
 fi
 
 fi
@@ -112,7 +84,5 @@ fi
 AC_SUBST(MPC_CFLAGS)
 AC_SUBST(MPC_LDFLAGS)
 AC_SUBST(MPC_LIBS)
-AC_SUBST(MPC_MAKELIB)
-AC_SUBST(MAKE_LIBTARGETS)
 AM_CONDITIONAL([WITH_MPC_IS_YES],[test x"$MPC" != xno])
 ])

--- a/m4/ac_check_mpfi.m4
+++ b/m4/ac_check_mpfi.m4
@@ -1,7 +1,7 @@
 # check for mpfi library
-# sets MPFI_CFLAGS, MPFI_LDFLAGS, MPFI_MAKELIB and MPFI_LIBS,
+# sets MPFI_CFLAGS, MPFI_LDFLAGS and MPFI_LIBS,
 # and MPFI_WITH, MPFI_DEPEND,
-# and MPFI=yes/no/extern
+# and MPFI=yes/no
 
 AC_DEFUN([AC_CHECK_MPFI],[
 temp_LIBS="$LIBS"
@@ -11,27 +11,14 @@ MPFI=unknown
 MPFI_WITH=""
 MPFI_DEPEND=""
 
-MPFI_MAKELIB=`printf 'mpfi: $(MPFILIB).tar.bz2 %s \\
-	mkdir -p $(EXTERN)/include $(EXTERN)/lib \\
-	if ! test -r $(EXTERN)/include/mpfi.h; then \\
-	    rm -rf $(MPFILIB) && \\
-	    tar -x -f $(MPFILIB).tar.bz2 -j -C extern && \\
-	    cd $(MPFILIB) && \\
-	    ./configure %s %s --prefix=$(EXTERN) && \\
-	    $(MAKE) install; \\
-	fi\n\n\n' "$MPFR_DEPEND" "$GMP_WITH" "$MPFR_WITH"`
-
 AC_ARG_WITH(mpfi,
  [  --with-mpfi=<location>
     Location at which the MPFI library was installed.
     If the argument is omitted, the library is assumed to be reachable
     under the standard search path (/usr, /usr/local,...).  Otherwise
     you must give the <path> to the directory which contains the
-    library. The special value "extern" asks Float
-    to compile a version of mpfi in the subdirectory extern/.],
- [if test "$withval" = extern; then
-    MPFI=extern
-  elif test "$withval" = no; then
+    library.],
+ [if test "$withval" = no; then
     MPFI=no
   elif test "$withval" = yes; then
     MPFI=yes
@@ -67,8 +54,6 @@ fi
 
 MPFI_LIBS="-lmpfi"
 
-if test "$MPFI" != extern; then
-
 AC_LANG_PUSH([C])
 temp_status=true
 CPPFLAGS="$CPPFLAGS $MPFI_CFLAGS $MPFR_CFLAGS"
@@ -79,25 +64,12 @@ AC_LANG_POP([C])
 
 if test "$temp_status" = false; then
     if test "$MPFI" = yes; then
-        AC_MSG_ERROR([library mpfi not found. Using --with-mpfi, specify its location, "extern" to compile it locally, or "no" to disable it.])
+        AC_MSG_ERROR([library mpfi not found. Using --with-mpfi, specify its location, or "no" to disable it.])
     else
-        MPFI=extern
+        MPFI=no
     fi
 else
     MPFI=yes
-fi
-
-fi
-
-if test "$MPFI" = extern; then
-
-MAKE_LIBTARGETS="$MAKE_LIBTARGETS mpfi"
-MPFI_CFLAGS='-I$(EXTERN)/include'
-MPFI_LDFLAGS='-L$(EXTERN)/lib'
-
-MPFI_WITH='--with-mpfi=$(EXTERN)'
-MPFI_DEPEND='mpfi'
-
 fi
 
 fi
@@ -112,7 +84,5 @@ fi
 AC_SUBST(MPFI_CFLAGS)
 AC_SUBST(MPFI_LDFLAGS)
 AC_SUBST(MPFI_LIBS)
-AC_SUBST(MPFI_MAKELIB)
-AC_SUBST(MAKE_LIBTARGETS)
 AM_CONDITIONAL([WITH_MPFI_IS_YES],[test x"$MPFI" != xno])
 ])

--- a/m4/ac_check_mpfr.m4
+++ b/m4/ac_check_mpfr.m4
@@ -1,7 +1,7 @@
 # check for mpfr library
-# sets MPFR_CFLAGS, MPFR_LDFLAGS, MPFR_MAKELIB and MPFR_LIBS,
+# sets MPFR_CFLAGS, MPFR_LDFLAGS and MPFR_LIBS,
 # and MPFR_WITH, MPFR_DEPEND,
-# and MPFR=yes/no/extern
+# and MPFR=yes/no
 
 AC_DEFUN([AC_CHECK_MPFR],[
 temp_LIBS="$LIBS"
@@ -11,27 +11,14 @@ MPFR=unknown
 MPFR_WITH=""
 MPFR_DEPEND=""
 
-MPFR_MAKELIB=`printf 'mpfr: $(MPFRLIB).tar.bz2  \\
-	mkdir -p $(EXTERN)/include $(EXTERN)/lib  \\
-	if ! test -r $(EXTERN)/include/mpfr.h; then \\
-	    rm -rf $(MPFRLIB) && \\
-	    tar -x -f $(MPFRLIB).tar.bz2 -j -C extern && \\
-	    cd $(MPFRLIB) && \\
-	    ./configure %s --prefix=$(EXTERN) && \\
-	    $(MAKE) install; \\
-	fi\n' "$GMP_WITH"`
-
 AC_ARG_WITH(mpfr,
  [  --with-mpfr=<location>
     Location at which the MPFR library was installed.
     If the argument is omitted, the library is assumed to be reachable
     under the standard search path (/usr, /usr/local,...).  Otherwise
     you must give the <path> to the directory which contains the
-    library. The special value "extern" asks Float
-    to compile a version of mpfr in the subdirectory extern/.],
- [if test "$withval" = extern; then
-    MPFR=extern
-  elif test "$withval" = no; then
+    library.],
+ [if test "$withval" = no; then
     MPFR=no
   elif test "$withval" = yes; then
     MPFR=yes
@@ -63,8 +50,6 @@ if test "$MPFR" != no; then
 
 MPFR_LIBS="-lmpfr"
 
-if test "$MPFR" != extern; then
-
 AC_LANG_PUSH([C])
 temp_status=true
 CPPFLAGS="$CPPFLAGS $MPFR_CFLAGS"
@@ -75,25 +60,12 @@ AC_LANG_POP([C])
 
 if test "$temp_status" = false; then
     if test "$MPFR" = yes; then
-        AC_MSG_ERROR([library mpfr not found. Using --with-mpfr, specify its location, "extern" to compile it locally, or "no" to disable it.])
+        AC_MSG_ERROR([library mpfr not found. Using --with-mpfr, specify its location, or "no" to disable it.])
     else
-        MPFR=extern
+        MPFR=no
     fi
 else
     MPFR=yes
-fi
-
-fi
-
-if test "$MPFR" = extern; then
-
-MAKE_LIBTARGETS="$MAKE_LIBTARGETS mpfr"
-MPFR_CFLAGS='-I$(EXTERN)/include'
-MPFR_LDFLAGS='-L$(EXTERN)/lib'
-
-MPFR_WITH='--with-mpfr=$(EXTERN)'
-MPFR_DEPEND='mpfr'
-
 fi
 
 fi
@@ -108,7 +80,5 @@ fi
 AC_SUBST(MPFR_CFLAGS)
 AC_SUBST(MPFR_LDFLAGS)
 AC_SUBST(MPFR_LIBS)
-AC_SUBST(MPFR_MAKELIB)
-AC_SUBST(MAKE_LIBTARGETS)
 AM_CONDITIONAL([WITH_MPFR_IS_YES],[test x"$MPFR" != xno])
 ])


### PR DESCRIPTION
With this commit, float now correctly detects the absence / presence
of its external dependencies, and allows a user who only has a subset
of them installed to compile float anyway. Previously, you either had
to have them all; or if not, then manually use --without-cxsx etc.

This resolves issue #24 