### PR TITLE
Use SET_TYPE_DATOBJ to set type of a T_DATOBJ

### DIFF
--- a/src/float.c
+++ b/src/float.c
@@ -35,7 +35,7 @@ Obj FLOAT_INFINITY_STRING, /* pretty strings */
 Obj NEW_DATOBJ(size_t size, Obj type)
 {
   Obj o = NewBag(T_DATOBJ,sizeof(Obj)+size);
-  TYPE_DATOBJ(o) = type;
+  SET_TYPE_DATOBJ(o, type);
   return o;
 }
 


### PR DESCRIPTION
Assigning to `TYPE_DATOBJ` will at some point in the future lead to a compiler error, as we will make its return value `const`.