### PR TITLE
discard QUIT_GAP in t/testall.g

### DIFF
--- a/tst/testall.g
+++ b/tst/testall.g
@@ -56,8 +56,6 @@ fi;
 # Report test results
 if success then
     Print("#I  No errors detected while testing package float\n");
-    QUIT_GAP(0);
 else
     Print("#I  Errors detected while testing package float\n");
-    QUIT_GAP(1);
 fi;


### PR DESCRIPTION
Description: test: testall.g: remove QUIT_GAP
 Implementing a QUIT_GAP in tst/testall.g provokes the end of GAP
 sessions when `TestPackage( "float" );' is invoked. This is surely
 not expected. This patch discards the two of them.
Origin: vendor, Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2017-11-17