### PR TITLE
neutralize perturbing Print in read.g

### DIFF
--- a/read.g
+++ b/read.g
@@ -2,7 +2,7 @@
 ##
 #W read.g                                                   Laurent Bartholdi
 ##
-#Y Copyright (C) 2008, Laurent Bartholdi
+#Y Copyright (C) 2008-2017, Laurent Bartholdi
 ##
 #############################################################################
 ##
@@ -38,7 +38,7 @@ if IsBound(CXSC_INT) then
     Add(modules,"cxsc");
     ReadPackage("float", "lib/cxsc.gi");
 fi;
-Print("Loading modules [",JoinStringsWithSeparator(modules,", "),"] for ");
+####Print("Loading modules [",JoinStringsWithSeparator(modules,", "),"] for ");
 
 if IsBound(IO_Pickle) then
     ReadPackage("float","lib/pickle.g");


### PR DESCRIPTION
Description: neutralize: read.g: perturbing message
 It appears that the message `Loading modules ...' prints by read.g
 does not allow to write appropriate tests mainly because it is a
 partial message that is meant to be completed by the standard message
 `PACKAGE_NAME PACKAGE_VERSION'. A more appropriate GAP mechanism,
 if exists, might be used instead. This patch comments the Print
 statement in order to allow reproducible tests.
Origin: vendor, Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2017-11-17