### PR TITLE
Modernize ac_find_gap.m4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,6 @@ matrix:
       compiler: clang
     - env: CFLAGS="-O2"
       compiler: gcc
-    - env: ABI=32
 
 branches:
   only:

--- a/m4/ac_find_gap.m4
+++ b/m4/ac_find_gap.m4
@@ -1,6 +1,6 @@
 # Find the location of GAP
 # Sets GAPROOT, GAPARCH and GAP_CPPFLAGS appropriately
-# Can be configured using --with-gaproot=... and CONFIGNAME=...
+# Can be configured using --with-gaproot=...
 #######################################################################
 
 AC_DEFUN([AC_FIND_GAP],
@@ -12,44 +12,22 @@ AC_DEFUN([AC_FIND_GAP],
 
   GAP_CPPFLAGS=""
 
-  #Allow the user to specify a configname:
-  AC_MSG_CHECKING([for CONFIGNAME])
-  AC_ARG_VAR(CONFIGNAME, [Set this to the CONFIGNAME of the GAP compilation
-    against which you want to compile this package. Leave this
-    variable empty for GAP versions < 4.5.])
-  if test "x$CONFIGNAME" = "x"; then
-    SYSINFO="sysinfo.gap"
-    AC_MSG_RESULT([none])
-  else
-    SYSINFO="sysinfo.gap-$CONFIGNAME"
-    AC_MSG_RESULT([$CONFIGNAME])
-  fi
-
   ######################################
   # Find the GAP root directory by
   # checking for the sysinfo.gap file
   AC_MSG_CHECKING([for GAP root directory])
-  DEFAULT_GAPROOTS="../.."
+  GAPROOT="../.."
 
   #Allow the user to specify the location of GAP
   #
   AC_ARG_WITH(gaproot,
     [AC_HELP_STRING([--with-gaproot=<path>], [specify root of GAP installation])],
-    [DEFAULT_GAPROOTS="$withval"])
+    [GAPROOT="$withval"])
 
-  havesysinfo=0
-  # Otherwise try likely directories
-  for GAPROOT in ${DEFAULT_GAPROOTS}
-  do
-    # Convert the path to absolute
-    GAPROOT=`cd $GAPROOT > /dev/null 2>&1 && pwd`
-    if test -e ${GAPROOT}/${SYSINFO}; then
-      havesysinfo=1
-      break
-    fi
-  done
+  # Convert the path to absolute
+  GAPROOT=`cd $GAPROOT > /dev/null 2>&1 && pwd`
 
-  if test "x$havesysinfo" = "x1"; then
+  if test -e ${GAPROOT}/sysinfo.gap; then
     AC_MSG_RESULT([${GAPROOT}])
   else
     AC_MSG_RESULT([Not found])
@@ -62,8 +40,7 @@ AC_DEFUN([AC_FIND_GAP],
     echo "  GAP's root directory using --with-gaproot=<path>"
     echo ""
     echo "  The GAP root directory (as far as this package is concerned) is"
-    echo "  the one containing the file sysinfo.gap and the subdirectories "
-    echo "  src/ and bin/."
+    echo "  the one containing the file sysinfo.gap"
     echo "********************************************************************"
     echo ""
 
@@ -75,27 +52,20 @@ AC_DEFUN([AC_FIND_GAP],
 
   AC_MSG_CHECKING([for GAP architecture])
   GAPARCH="Unknown"
-  . $GAPROOT/$SYSINFO
+  . $GAPROOT/sysinfo.gap
   if test "x$GAParch" != "x"; then
     GAPARCH=$GAParch
   fi
 
-  AC_ARG_WITH(gaparch,
-    [AC_HELP_STRING([--with-gaparch=<path>], [override GAP architecture string])],
-    [GAPARCH=$withval])
-  AC_MSG_RESULT([${GAPARCH}])
-
-  if test "x$GAPARCH" = "xUnknown" -o ! -d $GAPROOT/bin/$GAPARCH ; then
+  if test "x$GAPARCH" = "xUnknown" ; then
     echo ""
     echo "********************************************************************"
     echo "  ERROR"
     echo ""
     echo "  Found a GAP installation at $GAPROOT but could not find"
-    echo "  information about GAP's architecture in the"
-    echo "  file ${GAPROOT}/${SYSINFO} or did not find the directory"
-    echo "  ${GAPROOT}/bin/${GAPARCH}."
-    echo "  This file and directory should be present: please check your"
-    echo "  GAP installation."
+    echo "  information about GAP's architecture in the file"
+    echo "    ${GAPROOT}/sysinfo.gap ."
+    echo "  This file should be present: please check your GAP installation."
     echo "********************************************************************"
     echo ""
 

--- a/src/float.c
+++ b/src/float.c
@@ -26,6 +26,17 @@
 #include "src/compiled.h"
 #include "floattypes.h"
 
+
+// HACK HACK HACK: workaround an issue where atexit() calls are inserted by
+// the compiler into C++ code compiled with coverage tracking (via the
+// --coverage compiler and linker option); this then causes a linker error
+// when trying to load float.so on Linux with glibc, where atexit() is not
+// exported by libc.so.
+int atexit(void (*func)(void))
+{
+  return 0;
+}
+
 Obj FLOAT_INFINITY_STRING, /* pretty strings */
   FLOAT_NINFINITY_STRING,
   FLOAT_EMPTYSET_STRING,


### PR DESCRIPTION
* drop CONFIGNAME support
* make it possible to compile against future GAP releases with
  compatibility mode turned off