### PR TITLE
Stop using USE_GMP

### DIFF
--- a/src/floattypes.h
+++ b/src/floattypes.h
@@ -7,10 +7,6 @@
 **  This file declares the functions for the floating point package
 */
 
-#ifndef USE_GMP
-#error Float requires a GAP version with built-in GMP support
-#endif
-
 Obj MPZ_LONGINT (Obj obj);
 Obj INT_mpz(mpz_ptr z);
 mpz_ptr mpz_MPZ (Obj obj);


### PR DESCRIPTION
Since GAP 4.9, GAP always uses GMP to implement integers, so there is no point
in checking for USE_GMP. In fact, GAP only retained this define to allow the
float package to keep working. It'd be nice if we could remove it in GAP 4.11.