### PR TITLE
Install libmpfr-dev libmpfi-dev libmpc-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ addons:
     - libreadline-dev:i386
     - gcc-multilib
     - g++-multilib
+    - libmpfr-dev
+    - libmpfi-dev
+    - libmpc-dev
 
 matrix:
   include:


### PR DESCRIPTION
Float builds are passing, but many tests are skipped. This PR installs some libraries which may allow to run them.
```
Loading modules [] for float 0.9.1 ...
arithmetic
msecs: 0
#I  WARNING: skipping tests for MPFR
#I  WARNING: skipping tests for MPFI
#I  WARNING: skipping tests for MPC
#I  WARNING: skipping tests for CXSC
#I  WARNING: skipping tests for FPLLL
#I  No errors detected while testing package float
The command "scripts/build_pkg.sh && scripts/run_tests.sh" exited with 0.
```