### PR TITLE
Avoid using ErrorReturnObj

### DIFF
--- a/src/cxsc.C
+++ b/src/cxsc.C
@@ -185,10 +185,9 @@ static Obj CXSC_INT (Obj self, Obj f)
 
 static Obj CXSC_IEEE754 (Obj self, Obj f)
 {
-  while (!IS_MACFLOAT(f)) {
-    f = ErrorReturnObj("CXSC_IEEE754: object must be a float, not a %s",
-                       (Int)TNAM_OBJ(f),0,
-                       "You can return a float to continue");
+  if (!IS_MACFLOAT(f)) {
+    ErrorMayQuit("CXSC_IEEE754: object must be a float, not a %s",
+                       (Int)TNAM_OBJ(f),0);
   }
   return OBJ_RP(VAL_MACFLOAT(f));
 }

--- a/src/floattypes.h
+++ b/src/floattypes.h
@@ -15,14 +15,13 @@ mpz_ptr mpz_MPZ (Obj obj);
 #define IS_MACFLOAT(obj) (TNUM_OBJ(obj) == T_MACFLOAT)
 
 #define TEST_IS_INTOBJ(mp_name,obj)					\
-  while (!IS_INTOBJ(obj))						\
-    obj = ErrorReturnObj(#mp_name ": expected a small integer, not a %s", \
-			 (Int)TNAM_OBJ(obj),0,		\
-			 "You can return an integer to continue");
+  if (!IS_INTOBJ(obj))						\
+    ErrorMayQuit(#mp_name ": expected a small integer, not a %s", \
+			 (Int)TNAM_OBJ(obj),0);
 
 #define TEST_IS_STRING(gap_name,obj)				\
   if (!IsStringConv(obj))					\
-    ErrorQuit(#gap_name ": expected a string, not a %s",	\
+    ErrorMayQuit(#gap_name ": expected a string, not a %s",	\
 	      (Int)TNAM_OBJ(obj),0)
 
 extern Obj FLOAT_INFINITY_STRING,

--- a/src/mpc.c
+++ b/src/mpc.c
@@ -222,10 +222,9 @@ static Obj OBJBYEXTREP_MPC(Obj self, Obj list)
   int i;
   mp_prec_t prec = 0;
 
-  while (LEN_PLIST(list) != 4) {
-    list = ErrorReturnObj("OBJBYEXTREP_MPC: object must be a list of length 4, not a %s",
-		       (Int)TNAM_OBJ(list),0,
-		       "You can return a list to continue" );
+  if (LEN_LIST(list) != 4) {
+    ErrorMayQuit("OBJBYEXTREP_MPC: object must be a list of length 4, not a %s",
+		       (Int)TNAM_OBJ(list),0);
   }
 
   for (i = 0; i < 4; i += 2) {
@@ -451,12 +450,7 @@ static Obj VIEWSTRING_MPC(Obj self, Obj f, Obj digits)
 
 static Obj MPC_STRING(Obj self, Obj s, Obj prec)
 {
-  while (!IsStringConv(s))
-    {
-      s = ErrorReturnObj("MPC_STRING: object to be converted must be a string, not a %s",
-			 (Int)TNAM_OBJ(s),0,
-			 "You can return a string to continue" );
-    }
+  TEST_IS_STRING(MPC_STRING, s);
   TEST_IS_INTOBJ("MPC_STRING",prec);
   int n = INT_INTOBJ(prec);
   if (n == 0)

--- a/src/mpd.c
+++ b/src/mpd.c
@@ -255,12 +255,7 @@ static Obj VIEWSTRING_MPD(Obj self, Obj f, Obj digits)
 
 static Obj MPD_STRING(Obj self, Obj s, Obj prec)
 {
-  while (!IsStringConv(s))
-    {
-      s = ErrorReturnObj("MPD_STRING: object to be converted must be a string, not a %s",
-			 (Int)TNAM_OBJ(s),0,
-			 "You can return a string to continue" );
-    }
+  TEST_IS_STRING(MPD_STRING, s);
   TEST_IS_INTOBJ("MPD_STRING",prec);
   int n = INT_INTOBJ(prec);
   if (n == 0)

--- a/src/mpfi.c
+++ b/src/mpfi.c
@@ -166,10 +166,9 @@ static Obj OBJBYEXTREP_MPFI(Obj self, Obj list)
   int i;
   mp_prec_t prec = 0;
 
-  while (LEN_PLIST(list) != 4) {
-    list = ErrorReturnObj("OBJBYEXTREP_MPFI: object must be a list of length 4, not a %s",
-		       (Int)TNAM_OBJ(list),0,
-		       "You can return a list to continue" );
+  if (LEN_PLIST(list) != 4) {
+    ErrorMayQuit("OBJBYEXTREP_MPFI: object must be a list of length 4, not a %s",
+		       (Int)TNAM_OBJ(list),0);
   }
 
   for (i = 0; i < 4; i += 2) {
@@ -550,11 +549,7 @@ static Obj VIEWSTRING_MPFI(Obj self, Obj f, Obj digits)
 
 static Obj MPFI_STRING(Obj self, Obj s, Obj prec)
 {
-  while (!IsStringConv(s)) {
-    s = ErrorReturnObj("MPFI_STRING: object to be converted must be a string, not a %s",
-		       (Int)TNAM_OBJ(s),0,
-		       "You can return a string to continue" );
-  }
+  TEST_IS_STRING(MPFI_STRING, s);
   TEST_IS_INTOBJ("MPFI_STRING",prec);
   int n = INT_INTOBJ(prec);
   if (n == 0)

--- a/src/mpfr.c
+++ b/src/mpfr.c
@@ -31,10 +31,9 @@ Obj TYPE_MPFR, IsMPFRFloat, GAP_INFINITY;
 #define MANTISSA_MPFR(p) ((mp_limb_t *) ((p)+1))
 
 mpfr_ptr GET_MPFR(Obj obj) {
-  while (!IS_DATOBJ(obj) || DoFilter(IsMPFRFloat, obj) != True) {
-    obj = ErrorReturnObj("GET_MPFR: object must be an MPFR, not a %s",
-		       (Int)TNAM_OBJ(obj),0,
-		       "You can return an MPFR float to continue");
+  if (!IS_DATOBJ(obj) || DoFilter(IsMPFRFloat, obj) != True) {
+    ErrorMayQuit("GET_MPFR: object must be an MPFR, not a %s",
+		       (Int)TNAM_OBJ(obj),0);
   }
   mpfr_ptr p = MPFR_OBJ(obj);
   mpfr_custom_move (p, MANTISSA_MPFR(p));
@@ -305,10 +304,9 @@ static Obj MPFR_MPFRPREC(Obj self, Obj f, Obj prec)
 
 static Obj MPFR_MACFLOAT(Obj self, Obj f)
 {
-  while (!IS_MACFLOAT(f)) {
-    f = ErrorReturnObj("MPFR_MACFLOAT: object must be a float, not a %s",
-		       (Int)TNAM_OBJ(f),0,
-		       "You can return a float to continue");
+  if (!IS_MACFLOAT(f)) {
+    ErrorMayQuit("MPFR_MACFLOAT: object must be a float, not a %s",
+		       (Int)TNAM_OBJ(f),0);
   }
   Obj g = NEW_MPFR(64);
   mpfr_set_d (MPFR_OBJ(g), VAL_MACFLOAT(f), GMP_RNDN);
@@ -483,12 +481,7 @@ static Obj STRING_MPFR(Obj self, Obj f, Obj digits)
 
 static Obj MPFR_STRING(Obj self, Obj s, Obj prec)
 {
-  while (!IsStringConv(s))
-    {
-      s = ErrorReturnObj("MPFR_STRING: object to be converted must be a string, not a %s",
-			 (Int)TNAM_OBJ(s),0,
-			 "You can return a string to continue");
-    }
+  TEST_IS_STRING(MPFR_STRING, s);
   TEST_IS_INTOBJ("MPFR_STRING",prec);
   int n = INT_INTOBJ(prec);
   if (n == 0)


### PR DESCRIPTION
In GAP 4.11, most uses of ErrorReturnObj were removed, and in GAP 4.12
all of them. Background is that we found that it is extremely hard for
users to use them correctly, but incorrect use quickly leads to crashes,
or worse (nonsense results of computations). Based on some informal
polling, we found nobody who actually uses this feature other than in
extremely rare fringe cases, and nobody actually expressed any regret
about removing this feature.

Note that ErrorReturnVoid for now still is possible, there are a few
cases where it's useful, but we also suggest to minimize usage of that.