### PR TITLE
Fix warning: implicitly declaring library function 'isdigit'

### DIFF
--- a/src/mpfr.c
+++ b/src/mpfr.c
@@ -18,6 +18,7 @@
 #undef PACKAGE_URL
 #undef PACKAGE_VERSION
 
+#include <ctype.h>
 #include <string.h>
 #include <stdio.h>
 #include <gmp.h>


### PR DESCRIPTION
The GAP headers used to be very generous in which system headers they
included. This has been reduced on GAP master, and in general, it is a good
idea if code explicitly includes all headers it needs, instead of relying on
indirect includes to provide them.