### PR TITLE
Change package banner to use BannerFunction

### DIFF
--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -78,7 +78,39 @@ AvailabilityTest := function()
     return f<>fail;
 end,
                     
-BannerString := Concatenation(~.PackageName, " ", String(~.Version), " ...\n"),
+BannerFunction := function(info)
+    local str, modules;
+
+    str:= DefaultPackageBannerString(info);
+    modules := [];
+
+    if IsBound(MPFR_INT) then
+        Add(modules,"mpfr");
+    fi;
+    if IsBound(MPFI_INT) then
+        Add(modules,"mpfi");
+    fi;
+    if IsBound(MPC_INT) then
+        Add(modules,"mpc");
+    fi;
+    if IsBound(@FPLLL) then
+        Add(modules,"fplll");
+    fi;
+    if IsBound(CXSC_INT) then
+        Add(modules,"cxsc");
+    fi;
+    if Length(modules) = 0 then
+        modules := "none";
+    else
+        modules := JoinStringsWithSeparator(modules, ", ");
+    fi;
+
+    return ReplacedString(str, "Homepage",
+                Concatenation( "Loaded modules: ", modules, "\n",
+                "Homepage") );
+end,
+
+
 TestFile := "tst/testall.g",
 Keywords := ["floating-point"]
 ));

--- a/read.g
+++ b/read.g
@@ -17,30 +17,21 @@
 ReadPackage("float", "lib/polynomial.gi");
 ReadPackage("float", "lib/pslq.gi");
 
-modules@ := [];
 if IsBound(MPFR_INT) then
-    Add(modules@,"mpfr");
     ReadPackage("float", "lib/mpfr.gi");
 fi;
 if IsBound(MPFI_INT) then
-    Add(modules@,"mpfi");
     ReadPackage("float", "lib/mpfi.gi");
 fi;
 if IsBound(MPC_INT) then
-    Add(modules@,"mpc");
     ReadPackage("float", "lib/mpc.gi");
 fi;
 if IsBound(@FPLLL) then
-    Add(modules@,"fplll");
     ReadPackage("float", "lib/fplll.gi");
 fi;
 if IsBound(CXSC_INT) then
-    Add(modules@,"cxsc");
     ReadPackage("float", "lib/cxsc.gi");
 fi;
-
-PackageInfo("float")[1].BannerString := Concatenation("Loading modules [",JoinStringsWithSeparator(modules@,", "),"] for ",PackageInfo("float")[1].BannerString);
-Unbind(modules@);
 
 if IsBound(IO_Pickle) then
     ReadPackage("float","lib/pickle.g");


### PR DESCRIPTION
Banner before this patch:

    Loading modules [mpfr, mpfi, mpc, fplll] for float 0.9.9 ...

Banner after this patch:

    ─────────────────────────────────────────────────────────────
    Loading  float 0.9.9 (Floating-point numbers)
    by Laurent Bartholdi (http://www.uni-math.gwdg.de/laurent).
    Loaded modules: mpfr, mpfi, mpc, fplll
    Homepage: https://gap-packages.github.io/float/
    Report issues at https://github.com/gap-packages/float/issues
    ─────────────────────────────────────────────────────────────
