### PR TITLE
Fix building against 32bit GAP

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,9 @@ AC_C_INLINE
 # Locates GAP
 FIND_GAP
 
+CC="$GAP_CC"
+CXX="$GAP_CXX"
+
 LT_LIB_M
 AC_CHECK_MPFR
 if test "$MPFR" = yes; then


### PR DESCRIPTION
This patch ensures we inherit the -m32/-m64 flag from GAP

See also #61

UPDATE: This breaks older GAP versions. I'll revise this later to work there, too.