### PR TITLE
Fix CFLAGS/LDFLAGS/CPPFLAGS

### DIFF
--- a/m4/ac_check_cxsc.m4
+++ b/m4/ac_check_cxsc.m4
@@ -1,5 +1,5 @@
 # check for cxsc library
-# sets CXSC_CFLAGS, CXSC_LDFLAGS and CXSC_LIBS,
+# sets CXSC_CPPFLAGS, CXSC_LDFLAGS and CXSC_LIBS,
 # and CXSC_WITH, CXSC_DEPEND,
 # and CXSC=yes/no
 
@@ -25,7 +25,7 @@ AC_ARG_WITH(cxsc,
   else
     CXSC_WITH="$CXSC_WITH --with-cxsc=$withval"
     CXSC=yes
-    CXSC_CFLAGS="-I$withval/include"; CXSC_LDFLAGS="-L$withval/lib"
+    CXSC_CPPFLAGS="-I$withval/include"; CXSC_LDFLAGS="-L$withval/lib"
   fi]
 )
 
@@ -34,7 +34,7 @@ AC_ARG_WITH(cxsc-include,
     Location at which the cxsc include files were installed.],
  [CXSC=yes
   CXSC_WITH="$CXSC_WITH --with-cxsc-include=$withval"
-  CXSC_CFLAGS="-I$withval"]
+  CXSC_CPPFLAGS="-I$withval"]
 )
 
 AC_ARG_WITH(cxsc-lib,
@@ -52,7 +52,7 @@ CXSC_LIBS="-lcxsc"
 
 AC_LANG_PUSH([C++])
 temp_status=true
-CPPFLAGS="$CPPFLAGS $CXSC_CFLAGS"
+CPPFLAGS="$CPPFLAGS $CXSC_CPPFLAGS"
 AC_CHECK_HEADER(real.hpp,,[temp_status=false])
 LDFLAGS="$LDFLAGS $CXSC_LDFLAGS"
 AC_CHECK_LIB(cxsc,z_zadd,,[temp_status=false])
@@ -77,7 +77,7 @@ LIBS="$temp_LIBS"
 if test "$CXSC" != no; then
     AC_DEFINE([USE_CXSC],1,[use CXSC library])
 fi
-AC_SUBST(CXSC_CFLAGS)
+AC_SUBST(CXSC_CPPFLAGS)
 AC_SUBST(CXSC_LDFLAGS)
 AC_SUBST(CXSC_LIBS)
 AM_CONDITIONAL([WITH_CXSC_IS_YES],[test x"$CXSC" != xno])

--- a/m4/ac_check_fplll.m4
+++ b/m4/ac_check_fplll.m4
@@ -57,7 +57,7 @@ FPLLL_LIBS="-lfplll"
 AC_LANG_PUSH([C++])
 CPPFLAGS="$CPPFLAGS $FPLLL_CFLAGS $MPFR_CFLAGS"
 AC_CHECK_HEADER(fplll.h,[found_fplll=true],[found_fplll=false],[#include <mpfr.h>])
-LDFLAGS="$LDFLAGS $FPLLL_LDFLAGS $MPFR_CFLAGS"
+LDFLAGS="$LDFLAGS $FPLLL_LDFLAGS $MPFR_LDFLAGS"
 LIBS="$LIBS -lfplll -lgmp"
 if test "$found_fplll" = true; then
     AC_MSG_CHECKING([for lllReduction in -fplll (version 4.x)])

--- a/m4/ac_check_fplll.m4
+++ b/m4/ac_check_fplll.m4
@@ -1,5 +1,5 @@
 # check for fplll library
-# sets FPLLL_CFLAGS, FPLLL_LDFLAGS and FPLLL_LIBS,
+# sets FPLLL_CPPFLAGS, FPLLL_LDFLAGS and FPLLL_LIBS,
 # and FPLLL_WITH, FPLLL_DEPEND,
 # and FPLLL=yes/no
 
@@ -25,7 +25,7 @@ AC_ARG_WITH(fplll,
   else
     FPLLL_WITH="$FPLLL_WITH --with-fplll=$withval"
     FPLLL=yes
-    FPLLL_CFLAGS="-I$withval/include"; FPLLL_LDFLAGS="-L$withval/lib"
+    FPLLL_CPPFLAGS="-I$withval/include"; FPLLL_LDFLAGS="-L$withval/lib"
   fi]
 )
 
@@ -34,7 +34,7 @@ AC_ARG_WITH(fplll-include,
     Location at which the fplll include files were installed.],
  [FPLLL=yes
   FPLLL_WITH="$FPLLL_WITH --with-fplll-include=$withval"
-  FPLLL_CFLAGS="-I$withval"]
+  FPLLL_CPPFLAGS="-I$withval"]
 )
 
 AC_ARG_WITH(fplll-lib,
@@ -55,7 +55,7 @@ fi
 FPLLL_LIBS="-lfplll"
 
 AC_LANG_PUSH([C++])
-CPPFLAGS="$CPPFLAGS $FPLLL_CFLAGS $MPFR_CFLAGS"
+CPPFLAGS="$CPPFLAGS $FPLLL_CPPFLAGS $MPFR_CPPFLAGS"
 AC_CHECK_HEADER(fplll.h,[found_fplll=true],[found_fplll=false],[#include <mpfr.h>])
 LDFLAGS="$LDFLAGS $FPLLL_LDFLAGS $MPFR_LDFLAGS"
 LIBS="$LIBS -lfplll -lgmp"
@@ -94,7 +94,7 @@ LIBS="$temp_LIBS"
 if test "$FPLLL" != no; then
     AC_DEFINE([USE_FPLLL],1,[use FPLLL library])
 fi
-AC_SUBST(FPLLL_CFLAGS)
+AC_SUBST(FPLLL_CPPFLAGS)
 AC_SUBST(FPLLL_LDFLAGS)
 AC_SUBST(FPLLL_LIBS)
 AM_CONDITIONAL([WITH_FPLLL_IS_YES],[test x"$FPLLL" != xno])

--- a/m4/ac_check_mpc.m4
+++ b/m4/ac_check_mpc.m4
@@ -58,7 +58,7 @@ AC_LANG_PUSH([C])
 temp_status=true
 CPPFLAGS="$CPPFLAGS $MPC_CFLAGS $MPFR_CFLAGS"
 AC_CHECK_HEADER(mpc.h,,[temp_status=false],[#include <mpfr.h>])
-LDFLAGS="$LDFLAGS $MPC_LDFLAGS $MPFR_CFLAGS"
+LDFLAGS="$LDFLAGS $MPC_LDFLAGS $MPFR_LDFLAGS"
 AC_CHECK_LIB(mpc,mpc_sqrt,,[temp_status=false])
 AC_LANG_POP([C])
 

--- a/m4/ac_check_mpc.m4
+++ b/m4/ac_check_mpc.m4
@@ -1,5 +1,5 @@
 # check for mpc library
-# sets MPC_CFLAGS, MPC_LDFLAGS and MPC_LIBS,
+# sets MPC_CPPFLAGS, MPC_LDFLAGS and MPC_LIBS,
 # and MPC_WITH, MPC_DEPEND,
 # and MPC=yes/no
 
@@ -25,7 +25,7 @@ AC_ARG_WITH(mpc,
   else
     MPC_WITH="$MPC_WITH --with-mpc=$withval"
     MPC=yes
-    MPC_CFLAGS="-I$withval/include"; MPC_LDFLAGS="-L$withval/lib"
+    MPC_CPPFLAGS="-I$withval/include"; MPC_LDFLAGS="-L$withval/lib"
   fi]
 )
 
@@ -34,7 +34,7 @@ AC_ARG_WITH(mpc-include,
     Location at which the mpc include files were installed.],
  [MPC=yes
   MPC_WITH="$MPC_WITH --with-mpc-include=$withval"
-  MPC_CFLAGS="-I$withval"]
+  MPC_CPPFLAGS="-I$withval"]
 )
 
 AC_ARG_WITH(mpc-lib,
@@ -56,7 +56,7 @@ MPC_LIBS="-lmpc"
 
 AC_LANG_PUSH([C])
 temp_status=true
-CPPFLAGS="$CPPFLAGS $MPC_CFLAGS $MPFR_CFLAGS"
+CPPFLAGS="$CPPFLAGS $MPC_CPPFLAGS $MPFR_CPPFLAGS"
 AC_CHECK_HEADER(mpc.h,,[temp_status=false],[#include <mpfr.h>])
 LDFLAGS="$LDFLAGS $MPC_LDFLAGS $MPFR_LDFLAGS"
 AC_CHECK_LIB(mpc,mpc_sqrt,,[temp_status=false])
@@ -81,7 +81,7 @@ LIBS="$temp_LIBS"
 if test "$MPC" != no; then
     AC_DEFINE([USE_MPC],1,[use MPC library])
 fi
-AC_SUBST(MPC_CFLAGS)
+AC_SUBST(MPC_CPPFLAGS)
 AC_SUBST(MPC_LDFLAGS)
 AC_SUBST(MPC_LIBS)
 AM_CONDITIONAL([WITH_MPC_IS_YES],[test x"$MPC" != xno])

--- a/m4/ac_check_mpfi.m4
+++ b/m4/ac_check_mpfi.m4
@@ -58,7 +58,7 @@ AC_LANG_PUSH([C])
 temp_status=true
 CPPFLAGS="$CPPFLAGS $MPFI_CFLAGS $MPFR_CFLAGS"
 AC_CHECK_HEADER(mpfi.h,,[temp_status=false],[#include <mpfr.h>])
-LDFLAGS="$LDFLAGS $MPFI_LDFLAGS $MPFR_CFLAGS"
+LDFLAGS="$LDFLAGS $MPFI_LDFLAGS $MPFR_LDFLAGS"
 AC_CHECK_LIB(mpfi,mpfi_sqrt,,[temp_status=false])
 AC_LANG_POP([C])
 

--- a/m4/ac_check_mpfi.m4
+++ b/m4/ac_check_mpfi.m4
@@ -1,5 +1,5 @@
 # check for mpfi library
-# sets MPFI_CFLAGS, MPFI_LDFLAGS and MPFI_LIBS,
+# sets MPFI_CPPFLAGS, MPFI_LDFLAGS and MPFI_LIBS,
 # and MPFI_WITH, MPFI_DEPEND,
 # and MPFI=yes/no
 
@@ -25,7 +25,7 @@ AC_ARG_WITH(mpfi,
   else
     MPFI_WITH="$MPFI_WITH --with-mpfi=$withval"
     MPFI=yes
-    MPFI_CFLAGS="-I$withval/include"; MPFI_LDFLAGS="-L$withval/lib"
+    MPFI_CPPFLAGS="-I$withval/include"; MPFI_LDFLAGS="-L$withval/lib"
   fi]
 )
 
@@ -34,7 +34,7 @@ AC_ARG_WITH(mpfi-include,
     Location at which the mpfi include files were installed.],
  [MPFI=yes
   MPFI_WITH="$MPFI_WITH --with-mpfi-include=$withval"
-  MPFI_CFLAGS="-I$withval"]
+  MPFI_CPPFLAGS="-I$withval"]
 )
 
 AC_ARG_WITH(mpfi-lib,
@@ -56,7 +56,7 @@ MPFI_LIBS="-lmpfi"
 
 AC_LANG_PUSH([C])
 temp_status=true
-CPPFLAGS="$CPPFLAGS $MPFI_CFLAGS $MPFR_CFLAGS"
+CPPFLAGS="$CPPFLAGS $MPFI_CPPFLAGS $MPFR_CPPFLAGS"
 AC_CHECK_HEADER(mpfi.h,,[temp_status=false],[#include <mpfr.h>])
 LDFLAGS="$LDFLAGS $MPFI_LDFLAGS $MPFR_LDFLAGS"
 AC_CHECK_LIB(mpfi,mpfi_sqrt,,[temp_status=false])
@@ -81,7 +81,7 @@ LIBS="$temp_LIBS"
 if test "$MPFI" != no; then
     AC_DEFINE([USE_MPFI],1,[use MPFI library])
 fi
-AC_SUBST(MPFI_CFLAGS)
+AC_SUBST(MPFI_CPPFLAGS)
 AC_SUBST(MPFI_LDFLAGS)
 AC_SUBST(MPFI_LIBS)
 AM_CONDITIONAL([WITH_MPFI_IS_YES],[test x"$MPFI" != xno])

--- a/m4/ac_check_mpfr.m4
+++ b/m4/ac_check_mpfr.m4
@@ -1,5 +1,5 @@
 # check for mpfr library
-# sets MPFR_CFLAGS, MPFR_LDFLAGS and MPFR_LIBS,
+# sets MPFR_CPPFLAGS, MPFR_LDFLAGS and MPFR_LIBS,
 # and MPFR_WITH, MPFR_DEPEND,
 # and MPFR=yes/no
 
@@ -25,7 +25,7 @@ AC_ARG_WITH(mpfr,
   else
     MPFR_WITH="$MPFR_WITH --with-mpfr=$withval"
     MPFR=yes
-    MPFR_CFLAGS="-I$withval/include"; MPFR_LDFLAGS="-L$withval/lib"
+    MPFR_CPPFLAGS="-I$withval/include"; MPFR_LDFLAGS="-L$withval/lib"
   fi]
 )
 
@@ -34,7 +34,7 @@ AC_ARG_WITH(mpfr-include,
     Location at which the mpfr include files were installed.],
  [MPFR=yes
   MPFR_WITH="$MPFR_WITH --with-mpfr-include=$withval"
-  MPFR_CFLAGS="-I$withval"]
+  MPFR_CPPFLAGS="-I$withval"]
 )
 
 AC_ARG_WITH(mpfr-lib,
@@ -52,7 +52,7 @@ MPFR_LIBS="-lmpfr"
 
 AC_LANG_PUSH([C])
 temp_status=true
-CPPFLAGS="$CPPFLAGS $MPFR_CFLAGS"
+CPPFLAGS="$CPPFLAGS $MPFR_CPPFLAGS"
 AC_CHECK_HEADER(mpfr.h,,[temp_status=false])
 LDFLAGS="$LDFLAGS $MPFR_LDFLAGS"
 AC_CHECK_LIB(mpfr,mpfr_sqrt,,[temp_status=false])
@@ -77,7 +77,7 @@ LIBS="$temp_LIBS"
 if test "$MPFR" != no; then
     AC_DEFINE([USE_MPFR],1,[use MPFR library])
 fi
-AC_SUBST(MPFR_CFLAGS)
+AC_SUBST(MPFR_CPPFLAGS)
 AC_SUBST(MPFR_LDFLAGS)
 AC_SUBST(MPFR_LIBS)
 AM_CONDITIONAL([WITH_MPFR_IS_YES],[test x"$MPFR" != xno])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,35 +18,35 @@ float_la_LIBADD =
 
 if WITH_MPFR_IS_YES
 float_la_SOURCES += mpfr.c
-float_la_CFLAGS += $(MPFR_CFLAGS)
+float_la_CPPFLAGS += $(MPFR_CPPFLAGS)
 float_la_LDFLAGS += $(MPFR_LDFLAGS)
 float_la_LIBADD += $(MPFR_LIBS)
 endif ## WITH_MPFR_IS_YES
 
 if WITH_MPC_IS_YES
 float_la_SOURCES +=	mpc.c mp_poly.C
-float_la_CFLAGS += $(MPC_CFLAGS)
+float_la_CPPFLAGS += $(MPC_CPPFLAGS)
 float_la_LDFLAGS += $(MPC_LDFLAGS)
 float_la_LIBADD += $(MPC_LIBS)
 endif ## WITH_MPC_IS_YES
 
 if WITH_MPFI_IS_YES
 float_la_SOURCES += mpfi.c
-float_la_CFLAGS += $(MPFI_CFLAGS)
+float_la_CPPFLAGS += $(MPFI_CPPFLAGS)
 float_la_LDFLAGS += $(MPFI_LDFLAGS)
 float_la_LIBADD += $(MPFI_LIBS)
 endif ## WITH_MPFI_IS_YES
 
 if WITH_FPLLL_IS_YES
 float_la_SOURCES += fplll.C
-float_la_CFLAGS += $(FPLLL_CFLAGS)
+float_la_CPPFLAGS += $(FPLLL_CPPFLAGS)
 float_la_LDFLAGS += $(FPLLL_LDFLAGS)
 float_la_LIBADD += $(FPLLL_LIBS)
 endif ## WITH_FPLLL_IS_YES
 
 if WITH_CXSC_IS_YES
 float_la_SOURCES += cxsc.C cxsc_poly.C
-float_la_CPPFLAGS += $(CXSC_CFLAGS)
+float_la_CPPFLAGS += $(CXSC_CPPFLAGS)
 float_la_LDFLAGS += $(CXSC_LDFLAGS)
 float_la_LIBADD += $(CXSC_LIBS)
 endif ## WITH_CXSC_IS_YES


### PR DESCRIPTION
Without this, using a "manually" installed MPC does not work, as the required `-I` flags never reached the compiler. Similar for the `-L` flags for MPFR