### PR TITLE
Improve floattypes.h, cleanup

### DIFF
--- a/src/cxsc.C
+++ b/src/cxsc.C
@@ -16,22 +16,15 @@
 #undef PACKAGE_URL
 #undef PACKAGE_VERSION
 
-#include <gmp.h>
+#include "floattypes.h"
 
-extern "C" {
-#include "src/compiled.h"
-}
-#undef ZERO // clashes with ZERO in cxsc
 #include "except.hpp"
 #include "real.hpp"
 #include "complex.hpp"
 #include "interval.hpp"
 #include "cinterval.hpp"
-extern "C"
-{
-#include "floattypes.h"
-}
-#undef ZERO // make sure we use neither
+
+#include "cxsc_poly.h"
 
 #include "cpoly.hpp"
 #include "cipoly.hpp"

--- a/src/cxsc_poly.C
+++ b/src/cxsc_poly.C
@@ -15,6 +15,8 @@
 #include <real.hpp>
 #include <complex.hpp>
 
+#include "cxsc_poly.h"
+
 #define cpoly cpoly_CXSC
 
 #define xMAX_EXP DBL_MAX_EXP

--- a/src/cxsc_poly.h
+++ b/src/cxsc_poly.h
@@ -1,0 +1,1 @@
+int cpoly_CXSC(int degree, cxsc::complex coeffs[], cxsc::complex roots[], int prec);

--- a/src/float.c
+++ b/src/float.c
@@ -21,9 +21,7 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <gmp.h>
 
-#include "src/compiled.h"
 #include "floattypes.h"
 
 

--- a/src/floattypes.h
+++ b/src/floattypes.h
@@ -1,11 +1,22 @@
 /****************************************************************************
 **
-*W  gapfloat.h                    GAP source                Laurent Bartholdi
+*W  floattypes.h                  GAP source                Laurent Bartholdi
 **
 *Y  Copyright (C) 2008-2012 Laurent Bartholdi
 **
 **  This file declares the functions for the floating point package
 */
+
+#ifndef FLOATTYPES_H
+#define FLOATTYPES_H
+
+#include "gap_all.h"
+
+#include <gmp.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 Obj MPZ_LONGINT (Obj obj);
 Obj INT_mpz(mpz_ptr z);
@@ -156,14 +167,13 @@ static inline bool HAS_FILTER(Obj obj, Obj filter)
 #define CP_OBJ(obj) (*(cxsc::complex *) (ADDR_OBJ(obj)+1))
 #define CI_OBJ(obj) (*(cxsc::cinterval *) (ADDR_OBJ(obj)+1))
 
-#ifdef _CXSC_COMPLEX_HPP_INCLUDED
-int cpoly_CXSC(int degree, cxsc::complex coeffs[], cxsc::complex roots[], int prec);
-#endif
 int InitCXSCKernel (void);
 int InitCXSCLibrary (void);
 #endif
 
-/****************************************************************************
-**
-*E  gapfloat.h  . . . . . . . . . . . . . . . . . . . . . . . . . . ends here
-*/
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // FLOATTYPES_H

--- a/src/fplll.C
+++ b/src/fplll.C
@@ -20,12 +20,8 @@
 #undef PACKAGE_URL
 #undef PACKAGE_VERSION
 
-#include <gmp.h>
-
-extern "C" {
-#include "src/compiled.h"
 #include "floattypes.h"
-}
+
 #include <fplll.h>
 
 typedef Obj (*ObjFunc)(); // I never could get the () and * right

--- a/src/mpc.c
+++ b/src/mpc.c
@@ -18,9 +18,7 @@
 #undef PACKAGE_VERSION
 
 #include <stdio.h>
-#include <gmp.h>
 
-#include "src/compiled.h"
 #include "floattypes.h"
 
 /****************************************************************

--- a/src/mpfi.c
+++ b/src/mpfi.c
@@ -19,9 +19,7 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <gmp.h>
 
-#include "src/compiled.h"
 #include "floattypes.h"
 
 #define LMANTISSA_MPFI(p) ((mp_limb_t *) (p+1))

--- a/src/mpfr.c
+++ b/src/mpfr.c
@@ -21,10 +21,7 @@
 #include <ctype.h>
 #include <string.h>
 #include <stdio.h>
-#include <gmp.h>
 
-#include <mpfr.h>
-#include "src/compiled.h"
 #include "floattypes.h"
 
 Obj TYPE_MPFR, IsMPFRFloat, GAP_INFINITY;


### PR DESCRIPTION
- add include guards
- let it include gmp.h as it requires it
- let it include GAP headers, as it needs them; and since we now
  require GAP 4.11, also change the header included for that from
  `src/compiled.h` to `gap_all.h`
- move `cpoly_CXSC` declaration to its own header file, to avoid annoying
  include order shenanigans
