### PR TITLE
Fix compiler errors and warnings with C-XSC support

### DIFF
--- a/src/cpoly.C
+++ b/src/cpoly.C
@@ -336,7 +336,7 @@ static bool fxshft(const int l2, int deg, xcomplex *P, xcomplex *p, xcomplex *H,
 
 // Main function
 //
-extern "C" int cpoly(int degree, const xcomplex *poly, xcomplex *Roots, int prec)
+int cpoly(int degree, const xcomplex *poly, xcomplex *Roots, int prec)
 {
   default_prec = prec; // ugly!
   // __asm__("int3");

--- a/src/cxsc_poly.C
+++ b/src/cxsc_poly.C
@@ -22,7 +22,7 @@
 #define xINFIN DBL_MAX
   
 typedef double xreal;
-typedef cxsc::complex xcomplex;
+#define xcomplex cxsc::complex
 
 static const xreal xabs(const xcomplex &newz)
 {

--- a/src/cxsc_poly.h
+++ b/src/cxsc_poly.h
@@ -1,1 +1,1 @@
-int cpoly_CXSC(int degree, cxsc::complex coeffs[], cxsc::complex roots[], int prec);
+int cpoly_CXSC(int degree, const cxsc::complex coeffs[], cxsc::complex roots[], int prec);

--- a/src/mpc.c
+++ b/src/mpc.c
@@ -650,7 +650,7 @@ static Obj MPC_2MPFR (Obj self, Obj fl, Obj fr)
 
 static Obj ROOTPOLY_MPC (Obj self, Obj coeffs, Obj precision)
 {
-  int cpoly_MPC(int, mpc_t *, mpc_t *, mp_prec_t);
+  int cpoly_MPC(int, mpc_t *, mpc_t *, int);
   Obj result;
   Int i, numroots, degree = LEN_PLIST(coeffs)-1;
   mpc_t op[degree+1], zero[degree];
@@ -674,7 +674,7 @@ static Obj ROOTPOLY_MPC (Obj self, Obj coeffs, Obj precision)
 
   /* !!! first call routine on low-precision IEEE numbers; if got n roots, refine them using accelerated Newton's method (x - ff'/(f'f' - ff")), or (x-jf/f' with j such that f(new pt) in minimal. if fails, call the high-precision method */
 
-  numroots = cpoly_MPC (degree, op, zero, prec);
+  numroots = cpoly_MPC (degree, op, zero, (int)prec);
 
   for (i = 0; i <= degree; i++)
     mpc_clear(op[degree-i]);


### PR DESCRIPTION
I attempted to build version 1.0.1 for Fedora.  We build with C-XSC support.  The build failed like this:
```
cxsc_poly.C:18:15: error: conflicting declaration of 'int cpoly_CXSC(int, const cxsc::complex*, cxsc::complex*, int)' with 'C' linkage
   18 | #define cpoly cpoly_CXSC
      |               ^~~~~~~~~~
cpoly.C:339:16: note: in expansion of macro 'cpoly'
  339 | extern "C" int cpoly(int degree, const xcomplex *poly, xcomplex *Roots, int prec)
      |                ^~~~~
In file included from cxsc_poly.C:16:
cxsc_poly.h:1:5: note: previous declaration with 'C++' linkage
    1 | int cpoly_CXSC(int degree, const cxsc::complex coeffs[], cxsc::complex roots[], int prec);
      |     ^~~~~~~~~~
```
The first commit in this series fixes that by removing the `extern "C"`.  I was able to build with support for all of mpfr, mpfi, mpc, fplll, and cxsc with that change.

The second commit fixes this warning:
```
floattypes.h:165:5: warning: 'cpoly_CXSC' violates the C++ One Definition Rule [-Wodr]
  165 | int cpoly_CXSC(int degree, cxsc::complex coeffs[], cxsc::complex roots[], int prec);
      |     ^
cpoly.C:339:16: note: type mismatch in parameter 2
  339 | extern "C" int cpoly(int degree, const xcomplex *poly, xcomplex *Roots, int prec)
      |                ^
cpoly.C:339:16: note: type 'const struct xcomplex' itself violates the C++ One Definition Rule
/usr/include/cxsc/complex.hpp:49:7: note: the incompatible type is defined here
   49 | class complex
      |       ^
cpoly.C:339:16: note: 'cpoly_CXSC' was previously declared here
```

The third commit fixes the warning about parameter 2 of cpoly noted above.

The fourth commit fixes this warning:
```
mpc.c:653:7: warning: type of 'cpoly_MPC' does not match original declaration [-Wlto-type-mismatch]
  653 |   int cpoly_MPC(int, mpc_t *, mpc_t *, mp_prec_t);
      |       ^
cpoly.C:339:16: note: type mismatch in parameter 4
  339 | extern "C" int cpoly(int degree, const xcomplex *poly, xcomplex *Roots, int prec)
      |                ^
cpoly.C:339:16: note: type 'int' should match type 'mpfr_prec_t'
cpoly.C:339:16: note: 'cpoly_MPC' was previously declared here
cpoly.C:339:16: note: code may be misoptimized unless '-fno-strict-aliasing' is used
```

On various platforms, `mp_prec_t` may be a typedef of int, long, short, or unsigned short.