### PR TITLE
Fix building on Cygwin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -36,6 +36,11 @@ checkblocks:
 
 all: all-recursive
 	mkdir -p bin/@GAPARCH@
-	cp src/.libs/float.so bin/@GAPARCH@/
+if SYS_IS_CYGWIN
+	cp src/.libs/float.dll bin/@GAPARCH@/float.so
+else
+	cp src/.libs/float.so bin/@GAPARCH@/float.so
+endif
+
 
 #E Makefile.am . . . . . . . . . . . . . . . . . . . . . . . . . . . ends here

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,15 @@ else
 fi
 AC_CHECK_CXSC
 
+dnl ##
+dnl ## Detect Windows resp. Cygwin
+dnl ##
+case $host_os in
+  *cygwin* ) CYGWIN=yes;;
+         * ) CYGWIN=no;;
+esac
+AM_CONDITIONAL([SYS_IS_CYGWIN], [test "$CYGWIN" = "yes"])
+
 ################################################################
 # generate files
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,10 @@ float_la_CFLAGS = $(GAP_CFLAGS)
 float_la_LDFLAGS = $(GAP_LDFLAGS) -avoid-version -module
 float_la_LIBADD =
 
+if SYS_IS_CYGWIN
+float_la_LDFLAGS += -no-undefined -version-info 0:0:0 -Wl,$(GAPROOT)/bin/$(GAPARCH)/gap.dll
+endif
+
 if WITH_MPFR_IS_YES
 float_la_SOURCES += mpfr.c
 float_la_CPPFLAGS += $(MPFR_CPPFLAGS)


### PR DESCRIPTION
This patch fixes up building + running float on Cygwin. I'm happy to explain all the bits, but this is basically what we do in other packages, such as semigroups.

With this patch (I hope) float should be fully functional in the next GAP windows release, using libmpc & libmpfr (as those packages are already packaged with cygwin, unlike mpfr and fplll).