### PR TITLE
Use explicit conversions when calling cxsc::pow()

### DIFF
--- a/src/cxsc.C
+++ b/src/cxsc.C
@@ -857,16 +857,16 @@ static Obj EVALPOLY_CXSC(Obj self, Obj gapcoeffs, Obj gapt)
   Func2_CXSC_X(gap_name##_RI,R,I,RI_OBJ,oper);		\
   Func2_CXSC_X(gap_name##_CI,C,I,CI_OBJ,oper);
 
-cxsc::complex pow(cxsc::real &a, cxsc::complex &b) { return pow(a,b); }
-cxsc::interval pow(cxsc::real &a, cxsc::interval &b) { return pow(a,b); }
-cxsc::cinterval pow(cxsc::real &a, cxsc::cinterval &b) { return pow(a,b); }
-cxsc::cinterval pow(cxsc::complex &a, cxsc::interval &b) { return pow(a,b); }
-cxsc::cinterval pow(cxsc::complex &a, cxsc::cinterval &b) { return pow(a,b); }
-cxsc::interval pow(cxsc::interval &a, cxsc::real &b) { return pow(a,b); }
-cxsc::cinterval pow(cxsc::interval &a, cxsc::complex &b) { return pow(a,b); }
-cxsc::cinterval pow(cxsc::interval &a, cxsc::cinterval &b) { return pow(a,b); }
-cxsc::cinterval pow(cxsc::cinterval &a, cxsc::real &b) { return pow(a,b); }
-cxsc::cinterval pow(cxsc::cinterval &a, cxsc::complex &b) { return pow(a,b); }
+cxsc::complex pow(cxsc::real &a, cxsc::complex &b) { return pow(cxsc::complex(a),b); }
+cxsc::interval pow(cxsc::real &a, cxsc::interval &b) { return pow(cxsc::interval(a),b); }
+cxsc::cinterval pow(cxsc::real &a, cxsc::cinterval &b) { return pow(cxsc::cinterval(a),b); }
+cxsc::cinterval pow(cxsc::complex &a, cxsc::interval &b) { return pow(cxsc::cinterval(a),cxsc::cinterval(b)); }
+cxsc::cinterval pow(cxsc::complex &a, cxsc::cinterval &b) { return pow(cxsc::cinterval(a),b); }
+cxsc::interval pow(cxsc::interval &a, cxsc::real &b) { return pow(a,cxsc::interval(b)); }
+cxsc::cinterval pow(cxsc::interval &a, cxsc::complex &b) { return pow(cxsc::cinterval(a),cxsc::cinterval(b)); }
+cxsc::cinterval pow(cxsc::interval &a, cxsc::cinterval &b) { return pow(cxsc::cinterval(a),b); }
+cxsc::cinterval pow(cxsc::cinterval &a, cxsc::real &b) { return pow(a,cxsc::cinterval(b)); }
+cxsc::cinterval pow(cxsc::cinterval &a, cxsc::complex &b) { return pow(a,cxsc::cinterval(b)); }
 
 Func2_CXSC(SUM_CXSC,operator +);
 Func2_CXSC(DIFF_CXSC,operator -);


### PR DESCRIPTION
The Fedora project has started using GCC 12 (not yet released generally) to build packages.  I did a build of float 1.0.3 this morning, and saw these warnings:
```
cxsc.C: In function 'pow(cxsc::real&, cxsc::complex&)':
cxsc.C:860:15: warning: infinite recursion detected [-Winfinite-recursion]
  860 | cxsc::complex pow(cxsc::real &a, cxsc::complex &b) { return pow(a,b); }
      |               ^~~
cxsc.C:860:64: note: recursive call
  860 | cxsc::complex pow(cxsc::real &a, cxsc::complex &b) { return pow(a,b); }
      |                                                             ~~~^~~~~
cxsc.C: In function 'pow(cxsc::real&, cxsc::interval&)':
cxsc.C:861:16: warning: infinite recursion detected [-Winfinite-recursion]
  861 | cxsc::interval pow(cxsc::real &a, cxsc::interval &b) { return pow(a,b); }
      |                ^~~
cxsc.C:861:66: note: recursive call
  861 | cxsc::interval pow(cxsc::real &a, cxsc::interval &b) { return pow(a,b); }
      |                                                               ~~~^~~~~
cxsc.C: In function 'pow(cxsc::real&, cxsc::cinterval&)':
cxsc.C:862:17: warning: infinite recursion detected [-Winfinite-recursion]
  862 | cxsc::cinterval pow(cxsc::real &a, cxsc::cinterval &b) { return pow(a,b); }
      |                 ^~~
cxsc.C:862:68: note: recursive call
  862 | cxsc::cinterval pow(cxsc::real &a, cxsc::cinterval &b) { return pow(a,b); }
      |                                                                 ~~~^~~~~
cxsc.C: In function 'pow(cxsc::complex&, cxsc::interval&)':
cxsc.C:863:17: warning: infinite recursion detected [-Winfinite-recursion]
  863 | cxsc::cinterval pow(cxsc::complex &a, cxsc::interval &b) { return pow(a,b); }
      |                 ^~~
cxsc.C:863:70: note: recursive call
  863 | cxsc::cinterval pow(cxsc::complex &a, cxsc::interval &b) { return pow(a,b); }
      |                                                                   ~~~^~~~~
cxsc.C: In function 'pow(cxsc::complex&, cxsc::cinterval&)':
cxsc.C:864:17: warning: infinite recursion detected [-Winfinite-recursion]
  864 | cxsc::cinterval pow(cxsc::complex &a, cxsc::cinterval &b) { return pow(a,b); }
      |                 ^~~
cxsc.C:864:71: note: recursive call
  864 | cxsc::cinterval pow(cxsc::complex &a, cxsc::cinterval &b) { return pow(a,b); }
      |                                                                    ~~~^~~~~
cxsc.C: In function 'pow(cxsc::interval&, cxsc::real&)':
cxsc.C:865:16: warning: infinite recursion detected [-Winfinite-recursion]
  865 | cxsc::interval pow(cxsc::interval &a, cxsc::real &b) { return pow(a,b); }
      |                ^~~
cxsc.C:865:66: note: recursive call
  865 | cxsc::interval pow(cxsc::interval &a, cxsc::real &b) { return pow(a,b); }
      |                                                               ~~~^~~~~
cxsc.C: In function 'pow(cxsc::interval&, cxsc::complex&)':
cxsc.C:866:17: warning: infinite recursion detected [-Winfinite-recursion]
  866 | cxsc::cinterval pow(cxsc::interval &a, cxsc::complex &b) { return pow(a,b); }
      |                 ^~~
cxsc.C:866:70: note: recursive call
  866 | cxsc::cinterval pow(cxsc::interval &a, cxsc::complex &b) { return pow(a,b); }
      |                                                                   ~~~^~~~~
cxsc.C: In function 'pow(cxsc::interval&, cxsc::cinterval&)':
cxsc.C:867:17: warning: infinite recursion detected [-Winfinite-recursion]
  867 | cxsc::cinterval pow(cxsc::interval &a, cxsc::cinterval &b) { return pow(a,b); }
      |                 ^~~
cxsc.C:867:72: note: recursive call
  867 | cxsc::cinterval pow(cxsc::interval &a, cxsc::cinterval &b) { return pow(a,b); }
      |                                                                     ~~~^~~~~
cxsc.C: In function 'pow(cxsc::cinterval&, cxsc::real&)':
cxsc.C:868:17: warning: infinite recursion detected [-Winfinite-recursion]
  868 | cxsc::cinterval pow(cxsc::cinterval &a, cxsc::real &b) { return pow(a,b); }
      |                 ^~~
cxsc.C:868:68: note: recursive call
  868 | cxsc::cinterval pow(cxsc::cinterval &a, cxsc::real &b) { return pow(a,b); }
      |                                                                 ~~~^~~~~
cxsc.C: In function 'pow(cxsc::cinterval&, cxsc::complex&)':
cxsc.C:869:17: warning: infinite recursion detected [-Winfinite-recursion]
  869 | cxsc::cinterval pow(cxsc::cinterval &a, cxsc::complex &b) { return pow(a,b); }
      |                 ^~~
cxsc.C:869:71: note: recursive call
  869 | cxsc::cinterval pow(cxsc::cinterval &a, cxsc::complex &b) { return pow(a,b); }
      |                                                                    ~~~^~~~~
```

The explicit conversions in this patch convince GCC to make the intended function calls.