### PR TITLE
fplll: fix namespace issue

### DIFF
--- a/m4/ac_check_fplll.m4
+++ b/m4/ac_check_fplll.m4
@@ -68,7 +68,10 @@ if test "$found_fplll" = false; then
     AX_CXX_COMPILE_STDCXX([11],[noext],[mandatory])
     AC_CHECK_HEADER(fplll.h,[found_fplll=true],[found_fplll=false],[#include <mpfr.h>])
     AC_MSG_CHECKING([for lllReduction in -fplll (version 5.x)])
-    AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <fplll.h>],[ZZ_mat<mpz_t> M(3,3);lll_reduction(M, 0.99, 0.51, LM_WRAPPER);])],[AC_MSG_RESULT([yes]);found_fplll=5],[AC_MSG_RESULT([no]);found_fplll=false])
+    AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+#include <fplll.h>
+using namespace fplll;
+]],[ZZ_mat<mpz_t> M(3,3);lll_reduction(M, 0.99, 0.51, LM_WRAPPER);])],[AC_MSG_RESULT([yes]);found_fplll=5],[AC_MSG_RESULT([no]);found_fplll=false])
 fi
 AC_LANG_POP([C++])
 

--- a/src/fplll.C
+++ b/src/fplll.C
@@ -23,6 +23,8 @@
 #include "floattypes.h"
 
 #include <fplll.h>
+using namespace fplll;
+
 
 typedef Obj (*ObjFunc)(); // I never could get the () and * right
 


### PR DESCRIPTION
Description: fix fplll namespace issue
 Upstream maintainer of FPLLL has removed from `root` fplll.h
 'using namespace fplll' (commit e886a8899f71ca78711fdf420e6817432b2fe4be),
 this patch mimics the former behviour at the scale of this package.
Origin: vendor, Debian
Author: Jerome Benoit <calculus@rezozer.net>
Last-Update: 2022-07-03