### PR TITLE
Update some links in the manual

### DIFF
--- a/doc/float.xml
+++ b/doc/float.xml
@@ -27,10 +27,10 @@
   <Alt Only="HTML">
   <P/>
   The computer algebra system &GAP; is available at
-  <URL>https://gap-system.org</URL>.
+  <URL>https://www.gap-system.org</URL>.
   <P/>
   This documentation for <Package>Float</Package> is available at
-  <URL>https://www.gap-system.org/Manuals/pkg/float-&Version;/doc/manual.pdf</URL> in PDF format, and may be
+  <URL>https://docs.gap-system.org/pkg/float/doc/manual.pdf</URL> in PDF format, and may be
   accessed online at <URL>https://gap-packages.github.io/float/</URL>.
   <P/>
   The latest release of the package may be downloaded as


### PR DESCRIPTION
- the canonical GAP website URL is www.gap-system.org
- update link to package manual PDF on GAP website
