### PR TITLE
buildsys: locate GAP executable using info from sysinfo.gap

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -26,7 +26,7 @@ Changelog:
 	gitlog-to-changelog > $@
 
 doc: doc/float.xml gap/*.gd
-	@GAPROOT@/bin/gap.sh -A makedoc.g
+	@GAP@ -A makedoc.g
 
 checkblocks:
 	grep '<#GAPDoc' PackageInfo.g lib/*d | awk -F'"' '{print $$2}' | sort > @@-blocks

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,8 @@ AC_C_INLINE
 
 # Locates GAP
 FIND_GAP
+GAP="${GAP:-${GAPROOT}/bin/gap.sh}"
+AC_SUBST(GAP)
 
 LT_LIB_M
 AC_CHECK_MPFR


### PR DESCRIPTION
... at least in GAP versions putting it there; for older versions fall
back to using gap.sh
