### PR TITLE
Remove use of deprecated set_unexpected

### DIFF
--- a/src/cxsc.C
+++ b/src/cxsc.C
@@ -1427,11 +1427,6 @@ static StructGVarFunc GVarFuncs [] = {
   {0}
 };
 
-void cxsc_unexpected (void)
-{
-  ErrorQuit("cxsc::unexpected: Nobody expects the Spanish Inquisition!", 0,0);
-}
-
 void cxsc_terminate (void)
 {
   ErrorQuit("cxsc::terminate: I'll be back!", 0,0);
@@ -1456,7 +1451,6 @@ int InitCXSCKernel (void)
 
   ImportFuncFromLibrary ("Log2Int", &GAPLog2Int);
 
-  set_unexpected (cxsc_unexpected);
   set_terminate (cxsc_terminate);
   return 0;
 }


### PR DESCRIPTION
The `set_unexpected` function was deprecated in C++11, and has been removed entirely in C++17.  The default action when an uncaught exception is thrown is terminate, so the existing `set_terminate` call handles that case.
