### PR TITLE
Remove redundant definitions of ObjFunc

### DIFF
--- a/src/cxsc.C
+++ b/src/cxsc.C
@@ -198,8 +198,6 @@ static inline cxsc::cinterval CI_GET(cxsc::real x) { return _cinterval(x); }
     return OBJ_CP(cxsc_name(CI_OBJ(f)));			\
   }
 
-typedef Obj (*ObjFunc)(); // I never could get the () and * right
-
 #define Inc1_CXSC_arg(name,arg)					\
   { #name, 1, arg, (ObjFunc) name, "src/cxsc_float.c:" #name }
 #define Inc1_CXSC(name)					\

--- a/src/fplll.C
+++ b/src/fplll.C
@@ -26,8 +26,6 @@
 using namespace fplll;
 
 
-typedef Obj (*ObjFunc)(); // I never could get the () and * right
-
 template <class Z> void SET_INTOBJ(Z_NR<Z> &v, Obj z);
 template <class Z> Obj GET_INTOBJ(Z_NR<Z> &v);
 


### PR DESCRIPTION
`ObjFunc` is already defined in gap's common.h.  The redundant definitions become an issue if the gap definition changes, as suggested in https://github.com/gap-system/gap/issues/5857, making them fail to match.