### PR TITLE
migration to C23

### DIFF
--- a/src/mpc.c
+++ b/src/mpc.c
@@ -84,7 +84,7 @@ static inline Obj NEW_MPC( mp_prec_t prec )
     return g;						\
   }
 #define Inc1_MPC_arg(name,arg)		\
-  { #name, 1, arg, name, "src/mpc.c:" #name }
+  { #name, 1, arg, (ObjFunc)(void *)(name), "src/mpc.c:" #name }
 #define Inc1_MPC(name) Inc1_MPC_arg(name,"complex")
 
 Func1_MPC(PROJ_MPC,mpc_proj);
@@ -543,7 +543,7 @@ static Obj MPC_MPFR(Obj self, Obj f)
     return g;								\
   }
 #define Inc2_MPC_arg(name,arg)			\
-  { #name, 2, arg, name, "src/mpc.c:" #name }
+  { #name, 2, arg, (ObjFunc)(void *)(name), "src/mpc.c:" #name }
 #define Inc2_MPC(name) Inc2_MPC_arg(name##_MPC,"complex, complex"),	\
     Inc2_MPC_arg(name##_MPC_MPFR,"complex, real"),			\
     Inc2_MPC_arg(name##_MPFR_MPC,"real, complex")			\

--- a/src/mpfi.c
+++ b/src/mpfi.c
@@ -91,7 +91,7 @@ static inline Obj NEW_MPFI( mp_prec_t prec )
     return mpfi_name(GET_MPFI(f)) > 0 ? True : False;		\
   }
 #define Inc1_MPFI_arg(name,arg)		\
-  { #name, 1, arg, name, "src/mpfi.c:" #name }
+  { #name, 1, arg, (ObjFunc)(void *)(name), "src/mpfi.c:" #name }
 #define Inc1_MPFI(name) Inc1_MPFI_arg(name,"interval")
 
 Func1_MPFI(COS_MPFI,mpfi_cos);
@@ -666,7 +666,7 @@ static Obj BISECT_MPFI(Obj self, Obj f)
     return g;								\
   }
 #define Inc2_MPFI_arg(name,arg)			\
-  { #name, 2, arg, name, "src/mpfi.c:" #name }
+  { #name, 2, arg, (ObjFunc)(void *)(name), "src/mpfi.c:" #name }
 #define Inc2_MPFI(name) Inc2_MPFI_arg(name,"interval, interval")
 #define Inc2_MPFIX(name) Inc2_MPFI_arg(name##_MPFI,"interval, interval"), \
     Inc2_MPFI_arg(name##_MPFI_MPFR,"interval, real"),			\

--- a/src/mpfr.c
+++ b/src/mpfr.c
@@ -58,7 +58,7 @@ Obj NEW_MPFR (mp_prec_t prec)
     return g;							\
   }
 #define Inc1_MPFR_arg(name,arg)		\
-  { #name, 1, arg, name, "src/mpfr.c:" #name }
+  { #name, 1, arg, (ObjFunc)(void *)(name), "src/mpfr.c:" #name }
 #define Inc1_MPFR(name) Inc1_MPFR_arg(name,"float")
 
 Func1_MPFR(COS_MPFR,mpfr_cos);
@@ -496,7 +496,7 @@ static Obj MPFR_STRING(Obj self, Obj s, Obj prec)
     return g;								\
   }
 #define Inc2_MPFR_arg(name,arg)			\
-  { #name, 2, arg, name, "src/mpfr.c:" #name }
+  { #name, 2, arg, (ObjFunc)(void *)(name), "src/mpfr.c:" #name }
 #define Inc2_MPFR(name) Inc2_MPFR_arg(name,"float, float")
 
 Func2_MPFR(SUM_MPFR,mpfr_add);


### PR DESCRIPTION
This patch casts the handler in the macros Inc{1,2}_{MPFR,MPFI,MPC}_arg as the macro GVAR_FUNC in <GAP>/src/modules.h does. This patch closes Debian bug #1096673.