### PR TITLE
Improve handling of deps coming via homebrew

### DIFF
--- a/m4/ac_check_fplll.m4
+++ b/m4/ac_check_fplll.m4
@@ -24,10 +24,8 @@ AC_ARG_WITH([fplll],
     FPLLL_CPPFLAGS="-I$withval/include"
     FPLLL_LDFLAGS="-L$withval/lib"
   fi],
-  [AS_IF([command -v brew --prefix fplll >/dev/null 2>&1],[
-    AC_MSG_NOTICE([BREW fplll detected])
+  [AS_IF([command -v brew >/dev/null 2>&1],[
     withval=$(brew --prefix)
-    FPLLL=yes
     FPLLL_CPPFLAGS="-I$withval/include"
     FPLLL_LDFLAGS="-L$withval/lib"
   ])]

--- a/m4/ac_check_mpc.m4
+++ b/m4/ac_check_mpc.m4
@@ -24,10 +24,8 @@ AC_ARG_WITH([mpc],
     MPC_CPPFLAGS="-I$withval/include"
     MPC_LDFLAGS="-L$withval/lib"
   fi],
-  [AS_IF([command -v brew --prefix libmpc >/dev/null 2>&1],[
-    AC_MSG_NOTICE([BREW libmpc detected])
+  [AS_IF([command -v brew >/dev/null 2>&1],[
     withval=$(brew --prefix)
-    MPC=yes
     MPC_CPPFLAGS="-I$withval/include"
     MPC_LDFLAGS="-L$withval/lib"
   ])]
@@ -49,7 +47,7 @@ AC_ARG_WITH([mpc-lib],
 
 if test "$MPC" != no; then
 
-if test "$MPFR" = no; then
+if test "$MPC" != unknown &&test "$MPFR" = no; then
     AC_MSG_ERROR([Cannot have MPC without having MPFR too.])
 fi
 

--- a/m4/ac_check_mpfi.m4
+++ b/m4/ac_check_mpfi.m4
@@ -24,10 +24,8 @@ AC_ARG_WITH([mpfi],
     MPFI_CPPFLAGS="-I$withval/include"
     MPFI_LDFLAGS="-L$withval/lib"
   fi],
-  [AS_IF([command -v brew --prefix mpfi >/dev/null 2>&1],[
-    AC_MSG_NOTICE([BREW mpfi detected])
+  [AS_IF([command -v brew >/dev/null 2>&1],[
     withval=$(brew --prefix)
-    MPFI=yes
     MPFI_CPPFLAGS="-I$withval/include"
     MPFI_LDFLAGS="-L$withval/lib"
   ])]
@@ -49,7 +47,7 @@ AC_ARG_WITH([mpfi-lib],
 
 if test "$MPFI" != no; then
 
-if test "$MPFR" = no; then
+if test "$MPFI" != unknown && test "$MPFR" = no; then
     AC_MSG_ERROR([Cannot have MPFI without having MPFR too.])
 fi
 

--- a/m4/ac_check_mpfr.m4
+++ b/m4/ac_check_mpfr.m4
@@ -24,10 +24,8 @@ AC_ARG_WITH([mpfr],
     MPFR_CPPFLAGS="-I$withval/include"
     MPFR_LDFLAGS="-L$withval/lib"
   fi],
-  [AS_IF([command -v brew --prefix mpfr >/dev/null 2>&1],[
-    AC_MSG_NOTICE([BREW mpfr detected])
+  [AS_IF([command -v brew >/dev/null 2>&1],[
     withval=$(brew --prefix)
-    MPFR=yes
     MPFR_CPPFLAGS="-I$withval/include"
     MPFR_LDFLAGS="-L$withval/lib"
   ])]


### PR DESCRIPTION
Previously the detection would just fail if a user was using
homebrew but did not have e.g. mpfi installed. But it should only
fail if the user explicitly specified `--with-mpfi`, not when an
automation decided to try to see if mpfi has been installed via
homebrew.
