### PR TITLE
Disambiguate the type name "complex"

### DIFF
--- a/src/cxsc.C
+++ b/src/cxsc.C
@@ -614,7 +614,7 @@ static Obj CI_CXSC_STRING (Obj self, Obj str)
   if (s[0] == '[')
     s >> CI_OBJ(f);
   else if (s[0] == '(') {
-    complex l, r;
+    cxsc::complex l, r;
     std::string t = CSTR_STRING(str);
     s >> RndDown >> l;
     t >> RndUp >> r;
@@ -626,9 +626,9 @@ static Obj CI_CXSC_STRING (Obj self, Obj str)
     s >> RndDown >> l;
     t >> RndUp >> r;
     if (last == 'i' || last == 'I')
-      CI_OBJ(f) = cinterval(complex(0.0,l),complex(0.0,r));
+      CI_OBJ(f) = cinterval(cxsc::complex(0.0,l),cxsc::complex(0.0,r));
     else
-      CI_OBJ(f) = cinterval(complex(l),complex(r));
+      CI_OBJ(f) = cinterval(cxsc::complex(l),cxsc::complex(r));
   } 
     
   return f;
@@ -994,9 +994,9 @@ static inline real ldexp (real f, int s)
   real g = f; times2pown(g, s); return g;
 }
 
-static inline complex ldexp (complex f, int s)
+static inline cxsc::complex ldexp (cxsc::complex f, int s)
 {
-  return complex(ldexp(Re(f),s),ldexp(Im(f),s));
+  return cxsc::complex(ldexp(Re(f),s),ldexp(Im(f),s));
 }
 static inline interval ldexp (interval f, int s)
 {


### PR DESCRIPTION
When Fedora updated to GCC 15, the float package started failing to build if C-XSC support was included:
```
cxsc.C: In function 'OpaqueBag* CI_CXSC_STRING(Obj, Obj)':
cxsc.C:617:5: error: reference to 'complex' is ambiguous
  617 |     complex l, r;
      |     ^~~~~~~
In file included from /usr/include/c++/15/bits/stl_algobase.h:64,
                 from /usr/include/c++/15/string:53,
                 from /usr/include/cxsc/except.hpp:29,
                 from cxsc.C:68:
/usr/include/c++/15/bits/stl_pair.h:105:11: note: candidates are: 'template<class _Tp> class std::complex'
  105 |     class complex;
      |           ^~~~~~~
In file included from cxsc.C:70:
/usr/include/cxsc/complex.hpp:49:7: note:                 'class cxsc::complex'
   49 | class complex
      |       ^~~~~~~
```

This change disambiguates the type name `complex`, allowing the C-XSC interface to build successfully.